### PR TITLE
add support for collator groups

### DIFF
--- a/src/cmdGenerator.ts
+++ b/src/cmdGenerator.ts
@@ -163,6 +163,7 @@ export async function genCmd(
     return await genCumulusCollatorCmd(command, nodeSetup);
   }
 
+  args = [...args];
   args.push("--no-mdns");
 
   if (key) args.push(...["--node-key", key]);

--- a/src/configManager.ts
+++ b/src/configManager.ts
@@ -7,9 +7,10 @@ import {
   Node,
   Parachain,
   Override,
-  RelayChainConfig,
   NodeConfig,
   envVars,
+  Collator,
+  CollatorConfig,
 } from "./types";
 import { getSha256 } from "./utils";
 import {
@@ -160,10 +161,29 @@ export async function generateNetworkSpec(
         computedWasmPath,
         computedWasmCommand;
       const bootnodes = relayChainBootnodes;
-      const collatorBinary = parachain.collator.commandWithArgs
-        ? parachain.collator.commandWithArgs.split(" ")[0]
-        : parachain.collator.command
-        ? parachain.collator.command
+
+      // collator could by defined in groups or
+      // just using one collator definiton
+      let collators = [];
+      if(parachain.collator) collators.push(getCollatorFromConfig(parachain.collator, chainName, bootnodes));
+
+      for(const collatorGroup of parachain.collator_groups || []) {
+        for( let i = 0; i < collatorGroup.count; i++ ) {
+          collators.push(getCollatorFromConfig(collatorGroup.collator, chainName, bootnodes));
+        }
+      }
+
+      // use the first collator for state/wasm generation
+      const firstCollator = collators[0];
+      if(! firstCollator ) throw new Error(`No Collator defined for parachain ${parachain.id}, please review.`);
+
+      debug("firstCollator");
+      debug(firstCollator);
+
+      const collatorBinary = firstCollator.commandWithArgs
+        ? firstCollator.commandWithArgs.split(" ")[0]
+        : firstCollator.command
+        ? firstCollator.command
         : DEFAULT_ADDER_COLLATOR_BIN;
 
       if (parachain.genesis_state_path) {
@@ -185,7 +205,7 @@ export async function generateNetworkSpec(
           ? parachain.genesis_state_generator
           : `${collatorBinary} ${DEFAULT_GENESIS_GENERATE_SUBCOMMAND}`;
 
-        if (!collatorBinary.includes("adder")) {
+        if (!computedStateCommand.includes("adder")) {
           computedStateCommand += ` --parachain-id ${parachain.id}`;
         }
 
@@ -212,29 +232,11 @@ export async function generateNetworkSpec(
           : `${collatorBinary} ${DEFAULT_WASM_GENERATE_SUBCOMMAND} > {{CLIENT_REMOTE_DIR}}/${GENESIS_WASM_FILENAME}`;
       }
 
-      let args: string[] = [];
-      if (parachain.collator.args) args = args.concat(parachain.collator.args);
-
-      const env = [
-        { name: "COLORBT_SHOW_HIDDEN", value: "1" },
-        { name: "RUST_BACKTRACE", value: "FULL" },
-      ];
-      if (parachain.collator.env) env.push(...parachain.collator.env);
-
       let parachainSetup: Parachain = {
         id: parachain.id,
         addToGenesis:
           parachain.addToGenesis === undefined ? true : parachain.addToGenesis, // add by default
-        collator: {
-          name: getUniqueName(parachain.collator.name || "collator"),
-          command: collatorBinary,
-          commandWithArgs: parachain.collator.commandWithArgs,
-          image: parachain.collator.image || DEFAULT_COLLATOR_IMAGE,
-          chain: networkSpec.relaychain.chain,
-          args: parachain.collator.args || [],
-          env: env,
-          bootnodes,
-        },
+        collators
       };
 
       parachainSetup = {
@@ -328,6 +330,44 @@ function isValidatorbyArgs(nodeArgs: string[]): boolean {
     nodeArgs.includes(`--${acc}`)
   );
   return validatorAccount ? true : false;
+}
+
+function getCollatorFromConfig(
+  collatorConfig: CollatorConfig,
+  chain: string,
+  bootnodes: string[],
+): Collator {
+  console.log("collator config");
+  console.log(JSON.stringify(collatorConfig));
+  let args: string[] = [];
+  if (collatorConfig.args) args = args.concat(collatorConfig.args);
+
+  const env = [
+    { name: "COLORBT_SHOW_HIDDEN", value: "1" },
+    { name: "RUST_BACKTRACE", value: "FULL" },
+  ];
+  if (collatorConfig.env) env.push(...collatorConfig.env);
+
+  const collatorBinary = collatorConfig.commandWithArgs
+  ? collatorConfig.commandWithArgs.split(" ")[0]
+  : collatorConfig.command
+  ? collatorConfig.command
+  : DEFAULT_ADDER_COLLATOR_BIN;
+
+  const collator: Collator = {
+    name: getUniqueName(collatorConfig.name || "collator"),
+    command: collatorBinary,
+    commandWithArgs: collatorConfig.commandWithArgs,
+    image: collatorConfig.image || DEFAULT_COLLATOR_IMAGE,
+    args: collatorConfig.args || [],
+    chain,
+    env,
+    bootnodes,
+  };
+
+  console.log("collator");
+  console.log(JSON.stringify(collator));
+  return collator;
 }
 
 async function getNodeFromConfig(

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -482,7 +482,7 @@ export async function start(
           commandWithArgs: collator.commandWithArgs,
           chain: networkSpec.relaychain.chain,
           args: collator.args,
-          bootnodes: bootnodes,
+          bootnodes: collator.bootnodes,
           env: collator.env,
           telemetryUrl: "",
           overrides: [],

--- a/src/paras.ts
+++ b/src/paras.ts
@@ -48,7 +48,7 @@ export async function generateParachainFiles(
     let node: Node = {
       name: getUniqueName("temp-collator"),
       validator: false,
-      image: parachain.collator.image || DEFAULT_COLLATOR_IMAGE,
+      image: parachain.collators[0].image || DEFAULT_COLLATOR_IMAGE,
       fullCommand: commands.join(" && "),
       chain: chainName,
       bootnodes: [],

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -64,7 +64,7 @@ export interface Parachain {
   genesisStatePath?: string;
   genesisStateGenerator?: string;
   balance?: number;
-  collator: Collator;
+  collators: Collator[];
 }
 
 export interface CollatorNodeConfig {
@@ -180,6 +180,20 @@ export interface NodeGroupConfig {
   resources?: Resources;
 }
 
+export interface CollatorConfig {
+  image?: string;
+  command?: string;
+  commandWithArgs?: string;
+  name?: string;
+  args?: string[];
+  env?: envVars[];
+}
+
+export interface CollatorGroupConfig {
+  collator: CollatorConfig;
+  count: number;
+}
+
 export interface ParachainConfig {
   id: number;
   addToGenesis?: boolean;
@@ -189,14 +203,8 @@ export interface ParachainConfig {
   genesis_state_path?: string;
   genesis_state_generator?: string;
   bootnodes?: string[];
-  collator: {
-    image?: string;
-    command?: string;
-    commandWithArgs?: string;
-    name?: string;
-    args?: string[];
-    env?: envVars[];
-  };
+  collator?: CollatorConfig;
+  collator_groups?: CollatorGroupConfig[];
 }
 
 export interface fileMap {


### PR DESCRIPTION
cc @sandreim 
You can define `collator groups` and the `collator` key is still supported.

```toml
[[parachains]]
id = 2000
addToGenesis = true

  [parachains.collator]
  name = "collator"
  command = "adder-collator"
  args = ["-lparachain=debug"]

  [[parachains.collator_groups]]
    count = 2
    [parachains.collator_groups.collator]
    name = "collator"
    command = "adder-collator"
    args = ["-lparachain=debug"]

[types.Header]
number = "u64"
parent_hash = "Hash"
post_state = "Hash"
```