### PR TITLE
add parachain spec path to network and fix ports

### DIFF
--- a/src/cmdGenerator.ts
+++ b/src/cmdGenerator.ts
@@ -39,7 +39,8 @@ export async function genCumulusCollatorCmd(
   nodeSetup: Node,
   cfgPath: string = "/cfg",
   dataPath: string = "/data",
-  useWrapper = true
+  useWrapper = true,
+  portFlags?: { [flag: string]: number }
 ): Promise<string[]> {
   const { name, args, chain, parachainId } = nodeSetup;
   const parachainAddedArgs: any = {
@@ -53,8 +54,15 @@ export async function genCumulusCollatorCmd(
   };
 
   const colIndex = getCollatorIndex(name);
-  const collatorPort = await getRandomPort();
-  const collatorWsPort = await getRandomPort();
+  let collatorPort;
+  let collatorWsPort;
+  if(portFlags) {
+    collatorPort = portFlags["--port"];
+    collatorWsPort =  portFlags["--ws-port"];
+  } else {
+    collatorPort = await getRandomPort();
+    collatorWsPort = await getRandomPort();
+  }
   let fullCmd: string[] = [
     command,
     "--name",
@@ -196,7 +204,8 @@ export async function genCmd(
       nodeSetup,
       cfgPath,
       dataPath,
-      useWrapper
+      useWrapper,
+      portFlags
     );
   }
 

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -407,6 +407,7 @@ export async function start(
       }
 
       if (paraId) {
+        if(!network.paras[paraId]) network.addPara(paraId, parachainSpecPath);
         networkNode.parachainId = paraId;
         network.addNode(networkNode, Scope.PARA);
       } else {

--- a/src/test-runner.ts
+++ b/src/test-runner.ts
@@ -411,7 +411,8 @@ function parseAssertionLine(assertion: string) {
           return { name, wsUri, prometheusUri, userDefinedTypes };
         }),
         paras: Object.keys(network.paras).reduce((memo: any, paraId: any) => {
-          memo[paraId] = network.paras[paraId].map((node) => {
+          memo[paraId] = { spec: network.paras[paraId].spec }
+          memo[paraId].nodes = network.paras[paraId].nodes.map((node) => {
             return { ...node };
           });
           return memo;
@@ -581,7 +582,7 @@ function parseAssertionLine(assertion: string) {
       backchannelMap: BackchannelMap,
       testFile: string
     ) => {
-      const collator = network.paras[parachainId][0];
+      const collator = network.paras[parachainId].nodes[0];
       let node = network.node(collator.name);
       let api: ApiPromise = await connect(node.wsUri);
       const hash = await chainCustomSectionUpgrade(api);


### PR DESCRIPTION
- add parachain spec path to `network` object, used by the test-runner.
- Fix port management for cumulus based collators.

closes #117 