### PR TITLE
Add tempo to podman provider.

### DIFF
--- a/src/cmdGenerator.ts
+++ b/src/cmdGenerator.ts
@@ -42,7 +42,7 @@ export async function genCumulusCollatorCmd(
   useWrapper = true,
   portFlags?: { [flag: string]: number }
 ): Promise<string[]> {
-  const { name, args, chain, parachainId, key } = nodeSetup;
+  const { name, args, chain, parachainId, key, jaegerUrl } = nodeSetup;
   const parachainAddedArgs: any = {
     "--name": true,
     "--collator": true,
@@ -81,6 +81,8 @@ export async function genCumulusCollatorCmd(
     "--ws-port",
     collatorWsPort.toString(),
   ];
+
+  if(jaegerUrl) args.push(...["--jaeger-agent", jaegerUrl]);
 
   if (nodeSetup.args.length > 0) {
     let argsCollator = null;
@@ -183,6 +185,7 @@ export async function genCmd(
     bootnodes,
     args,
     zombieRole,
+    jaegerUrl
   } = nodeSetup;
 
   // fullCommand is NOT decorated by the `zombie` wrapper
@@ -205,6 +208,8 @@ export async function genCmd(
   else args.push(...["--telemetry-url", telemetryUrl]);
 
   if (prometheus && ! args.includes("--prometheus-external")) args.push("--prometheus-external");
+
+  if(jaegerUrl) args.push(...["--jaeger-agent", jaegerUrl]);
 
   if (validator && ! args.includes("--validator")) args.push("--validator");
 

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -299,6 +299,12 @@ export async function start(
     }
 
     const monitorIsAvailable = await client.isPodMonitorAvailable();
+    let jaegerUrl: string;
+    if(client.providerName === "podman") {
+      const jaegerIp = client.getPodIp("tempo");
+      const jaegerPort = client.getPodIp(14268, "tempo");
+      jaegerUrl = `${jaegerPort}:${jaegerPort}`;
+    }
 
     const spawnNode = async (
       node: Node,
@@ -309,6 +315,8 @@ export async function start(
       // for relay chain we can have more than one bootnode.
       if (node.zombieRole === "node" || node.zombieRole === "collator")
         node.bootnodes = node.bootnodes.concat(bootnodes);
+
+      if(jaegerUrl) node.jaegerUrl = jaegerUrl;
 
       debug(`creating node: ${node.name}`);
       const podDef = await (node.name === "bootnode"

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -301,9 +301,8 @@ export async function start(
     const monitorIsAvailable = await client.isPodMonitorAvailable();
     let jaegerUrl: string;
     if(client.providerName === "podman") {
-      const jaegerIp = client.getPodIp("tempo");
-      const jaegerPort = client.getPodIp(14268, "tempo");
-      jaegerUrl = `${jaegerPort}:${jaegerPort}`;
+      const jaegerIp = await client.getPodIp("tempo");
+      jaegerUrl = `${jaegerIp}:6831`;
     }
 
     const spawnNode = async (

--- a/src/providers/native/dynResourceDefinition.ts
+++ b/src/providers/native/dynResourceDefinition.ts
@@ -67,7 +67,7 @@ export async function genNodeDef(
 
   let computedCommand;
   const launchCommand = nodeSetup.command || DEFAULT_COMMAND;
-  if( nodeSetup.zombieRole === "cumulus-collator" || nodeSetup.zombieRole === "collator") {
+  if( nodeSetup.zombieRole === "cumulus-collator" ) {
     computedCommand = await genCumulusCollatorCmd(launchCommand, nodeSetup, cfgPath, dataPath, false, portFlags);
   } else {
     computedCommand = await genCmd(nodeSetup, cfgPath, dataPath, false, portFlags);

--- a/src/providers/podman/dynResourceDefinition.ts
+++ b/src/providers/podman/dynResourceDefinition.ts
@@ -196,6 +196,87 @@ datasources:
   };
 }
 
+export async function genTempoDef(
+  namespace: string
+): Promise<any> {
+  const client = getClient();
+
+  const volume_mounts = [
+    { name: "tempo-cfg", mountPath: "/etc/tempo", readOnly: false },
+    { name: "tempo-data", mountPath: "/data", readOnly: false },
+  ];
+  const cfgPath = `${client.tmpDir}/tempo/etc`;
+  const dataPath = `${client.tmpDir}/tempo/data`;
+  await fs.mkdir(cfgPath, { recursive: true });
+  await fs.mkdir(dataPath, { recursive: true });
+
+  const devices = [
+    { name: "tempo-cfg", hostPath: { type: "Directory", path: cfgPath } },
+    { name: "tempo-data", hostPath: { type: "Directory", path: dataPath } },
+  ];
+
+  await fs.copyFile("../../../static-configs/tempo.yaml",`${cfgPath}/tempo.yaml`);
+
+  const ports = [
+    {
+      containerPort: 14268,
+      name: "jaeger_ingest",
+      hostPort: await getRandomPort(),
+    },
+    {
+      containerPort: 3200,
+      name: "tempo",
+      hostPort: await getRandomPort(),
+    },
+    {
+      containerPort: 4317,
+      name: "otlp_grpc",
+      hostPort: await getRandomPort(),
+    },
+    {
+      containerPort: 4318,
+      name: "otlp_http",
+      hostPort: await getRandomPort(),
+    },
+    {
+      containerPort: 9411,
+      name: "zipkin",
+      hostPort: await getRandomPort(),
+    }
+  ];
+
+  const containerDef = {
+    image: "grafana/tempo:latest",
+    name: "tempo",
+    command: [ "-config.file=/etc/tempo/tempo.yaml" ],
+    imagePullPolicy: "Always",
+    ports,
+    volumeMounts: volume_mounts,
+  };
+
+  return {
+    apiVersion: "v1",
+    kind: "Pod",
+    metadata: {
+      name: "tempo",
+      namespace: namespace,
+      labels: {
+        "app.kubernetes.io/name": namespace,
+        "app.kubernetes.io/instance": "tempo",
+        "zombie-role": "tempo",
+        app: "zombienet",
+        "zombie-ns": namespace,
+      },
+    },
+    spec: {
+      hostname: "tempo",
+      containers: [containerDef],
+      restartPolicy: "OnFailure",
+      volumes: devices,
+    },
+  };
+}
+
 export async function genNodeDef(
   namespace: string,
   nodeSetup: Node

--- a/src/providers/podman/podmanClient.ts
+++ b/src/providers/podman/podmanClient.ts
@@ -92,11 +92,16 @@ export class PodmanClient extends Client {
     await this.createResource(tempoSpec, false, false);
     const jaegerPort = tempoSpec.spec.containers[0].ports[0].hostPort;
     const tempoPort = tempoSpec.spec.containers[0].ports[0].hostPort;
+    console.log(
+      `\n\t Monitor: ${decorators.green(
+        tempoSpec.metadata.name
+      )} - url: http://127.0.0.1:${tempoPort}`
+    );
 
 
     const prometheusIp = await this.getPodIp("prometheus");
     const tempoIp = await this.getPodIp("tempo");
-    const grafanaSpec = await genGrafanaDef(this.namespace, prometheusIp);
+    const grafanaSpec = await genGrafanaDef(this.namespace, prometheusIp.toString(), tempoIp.toString());
     await this.createResource(grafanaSpec, false, false);
     const grafanaPort = grafanaSpec.spec.containers[0].ports[0].hostPort;
     console.log(

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -141,6 +141,7 @@ export interface Node {
   addToBootnodes?: boolean;
   resources?: Resources;
   parachainId?: number;
+  jaegerUrl?: string;
 }
 
 export interface Collator {

--- a/static-configs/tempo.yaml
+++ b/static-configs/tempo.yaml
@@ -1,0 +1,45 @@
+server:
+  http_listen_port: 3200
+
+distributor:
+  receivers:                           # this configuration will listen on all ports and protocols that tempo is capable of.
+    jaeger:                            # the receives all come from the OpenTelemetry collector.  more configuration information can
+      protocols:                       # be found there: https://github.com/open-telemetry/opentelemetry-collector/tree/main/receiver
+        thrift_http:                   #
+        grpc:                          # for a production deployment you should only enable the receivers you need!
+        thrift_binary:
+        thrift_compact:
+    zipkin:
+    otlp:
+      protocols:
+        http:
+        grpc:
+    opencensus:
+
+ingester:
+  trace_idle_period: 10s               # the length of time after a trace has not received spans to consider it complete and flush it
+  max_block_bytes: 1_000_000           # cut the head block when it hits this size or ...
+  max_block_duration: 5m               #   this much time passes
+
+compactor:
+  compaction:
+    compaction_window: 1h              # blocks in this time window will be compacted together
+    max_block_bytes: 100_000_000       # maximum size of compacted blocks
+    block_retention: 1h
+    compacted_block_retention: 10m
+
+storage:
+  trace:
+    backend: local                     # backend configuration to use
+    block:
+      bloom_filter_false_positive: .05 # bloom filter false positive rate.  lower values create larger filters but fewer false positives
+      index_downsample_bytes: 1000     # number of bytes per index record
+      encoding: zstd                   # block encoding/compression.  options: none, gzip, lz4-64k, lz4-256k, lz4-1M, lz4, snappy, zstd, s2
+    wal:
+      path: /tmp/tempo/wal             # where to store the the wal locally
+      encoding: snappy                 # wal encoding/compression.  options: none, gzip, lz4-64k, lz4-256k, lz4-1M, lz4, snappy, zstd, s2
+    local:
+      path: /tmp/tempo/blocks
+    pool:
+      max_workers: 100                 # worker pool determines the number of parallel requests to the object store backend
+      queue_depth: 10000


### PR DESCRIPTION
Hi @drahnr, this adds support to send spans to `tempo` with `podman` provider. For native we can check if the user have podman/docker and use it for spawn the grafana/prometheus/tempo stack.
Thx!
cover partially #140.

