### PR TITLE
Enable tracing default

### DIFF
--- a/src/configGenerator.ts
+++ b/src/configGenerator.ts
@@ -82,6 +82,7 @@ export async function generateNetworkSpec(
   // settings
   networkSpec.settings = {
     timeout: DEFAULT_GLOBAL_TIMEOUT,
+    enable_tracing: true,
     ...(config.settings ? config.settings : {}),
   };
 

--- a/src/providers/k8s/kubeClient.ts
+++ b/src/providers/k8s/kubeClient.ts
@@ -53,7 +53,7 @@ export class KubeClient extends Client {
     this.configPath = configPath;
     this.namespace = namespace;
     this.debug = true;
-    this.timeout = 120; // secs
+    this.timeout = 300; // secs
     this.tmpDir = tmpDir;
     this.localMagicFilepath = `${tmpDir}/finished.txt`;
     this.remoteDir = DEFAULT_REMOTE_DIR;
@@ -537,7 +537,7 @@ export class KubeClient extends Client {
     const args = ["logs"];
     if (since && since > 0) args.push(`--since=${since}s`);
     if (withTimestamp) args.push("--timestamps=true");
-    args.push(...[podName, "--namespace", this.namespace]);
+    args.push(...[podName, "-c", podName, "--namespace", this.namespace]);
 
     const result = await this.runCommand(args, undefined, false);
     return result.stdout;


### PR DESCRIPTION
- Enable tracing by default in `k8s` provider.
- increate timeout to spawn a pod in `k8s`.