### PR TITLE
Grep for listen connections for collators in native provider

### DIFF
--- a/src/providers/native/nativeClient.ts
+++ b/src/providers/native/nativeClient.ts
@@ -277,7 +277,7 @@ export class NativeClient extends Client {
     let t = this.timeout;
     const args = [
       "-c",
-      `grep -E 'Listening for new connections|Is collating'  ${logFile} | wc -l`,
+      `grep 'Listening for new connections'  ${logFile} | wc -l`,
     ];
     do {
       const result = await this.runCommand(args);


### PR DESCRIPTION
- Fix, `ready` state for collator in native provider.