### PR TITLE
Remove Vault from CI and change CI vars

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -111,6 +111,7 @@ package:
   script:
     - test "$Docker_Hub_User_Parity" -a "$Docker_Hub_Pass_Parity" ||
         ( echo "no docker credentials provided"; exit 1 )
+    - echo $Docker_Hub_User_Parity
     - buildah bud
         --format=docker
         --build-arg VCS_REF="${CI_COMMIT_SHA}"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,9 +18,6 @@ stages:
 
 variables:
   CI_IMAGE:                        "node:16.10"
-  VAULT_SERVER_URL:                "https://vault.parity-mgmt-vault.parity.io"
-  VAULT_AUTH_PATH:                 "gitlab-parity-io-jwt"
-  VAULT_AUTH_ROLE:                 "cicd_gitlab_parity_${CI_PROJECT_NAME}"
   DOCKERFILE:                      scripts/ci/docker/zombienet_injected.Dockerfile
   DOCKERHUB_REPO:                  paritytech
   IMAGE_NAME:                      $DOCKERHUB_REPO/zombienet
@@ -112,7 +109,7 @@ package:
 # template task for building and pushing an image
 .build-push-docker-image:          &build-push-docker-image
   script:
-    - test "$DOCKER_HUB_USER" -a "$DOCKER_HUB_PASS" ||
+    - test "$Docker_Hub_User_Parity" -a "$Docker_Hub_Pass_Parity" ||
         ( echo "no docker credentials provided"; exit 1 )
     - buildah bud
         --format=docker
@@ -122,8 +119,8 @@ package:
         --tag "$IMAGE_NAME:$VERSION"
         --tag "$IMAGE_NAME:latest"
         --file "$DOCKERFILE" .
-    - echo "$DOCKER_HUB_PASS" |
-        buildah login --username "$DOCKER_HUB_USER" --password-stdin docker.io
+    - echo "$Docker_Hub_Pass_Parity" |
+        buildah login --username "$Docker_Hub_User_Parity" --password-stdin docker.io
     - buildah info
     - echo "Effective tags = ${VERSION} latest"
     - buildah push --format=v2s2 "$IMAGE_NAME:$VERSION"
@@ -152,8 +149,8 @@ publish-docker-pr:
   variables:
     CI_IMAGE:                      quay.io/buildah/stable
     DOCKERHUB_REPO:                paritypr
-    DOCKER_HUB_USER:               $DOCKER_HUB_PR_USER
-    DOCKER_HUB_PASS:               $DOCKER_HUB_PR_PASS
+    Docker_Hub_User_Parity:        $DOCKER_HUB_PR_USER
+    Docker_Hub_Pass_Parity:        $DOCKER_HUB_PR_PASS
   before_script:
     - export VERSION=${CI_COMMIT_SHORT_SHA}
   <<:                              *kubernetes-env
@@ -162,13 +159,6 @@ publish-docker-pr:
 
 publish-docker:
   stage:                           publish
-  secrets:
-    DOCKER_HUB_USER:
-      vault:                       cicd/gitlab/parity/DOCKER_HUB_USER@kv
-      file:                        false
-    DOCKER_HUB_PASS:
-      vault:                       cicd/gitlab/parity/DOCKER_HUB_PASS@kv
-      file:                        false
   variables:
     CI_IMAGE:                      quay.io/buildah/stable
   before_script:


### PR DESCRIPTION
PR removes Vault integration from GitLab CI related to this https://github.com/paritytech/ci_cd/issues/377
Changes coincident CI variables in use from project to group ones.