### PR TITLE
Changes to support collators and reserved nodes

### DIFF
--- a/src/chain-spec.ts
+++ b/src/chain-spec.ts
@@ -131,9 +131,9 @@ export async function addParachainToGenesis(
 export async function changeGenesisConfig(spec_path: string, updates: any) {
   let rawdata = fs.readFileSync(spec_path);
   let chainSpec = JSON.parse(rawdata);
-
+  const msg = `⚙ Updating Chain Genesis Configuration (path: ${spec_path})`;
   console.log(
-    `\n\t\t ${decorators.green("⚙ Updating Relay Chain Genesis Configuration")}`
+    `\n\t\t ${decorators.green(msg)}`
   );
 
   if (chainSpec.genesis) {

--- a/src/configGenerator.ts
+++ b/src/configGenerator.ts
@@ -166,7 +166,17 @@ export async function generateNetworkSpec(
       // collator could by defined in groups or
       // just using one collator definiton
       let collators = [];
-      for(const collatorConfig of parachain.nodes || []) {
+      if(parachain.collator)
+        collators.push(
+          getCollatorNodeFromConfig(
+            parachain.collator,
+            parachain.id,
+            chainName,
+            bootnodes,
+            Boolean(parachain.cumulus_based)
+          )
+        );
+      for(const collatorConfig of parachain.collators || []) {
         collators.push(
           getCollatorNodeFromConfig(
             collatorConfig,
@@ -178,7 +188,7 @@ export async function generateNetworkSpec(
         );
       }
 
-      for (const collatorGroup of parachain.node_groups || []) {
+      for (const collatorGroup of parachain.collator_groups || []) {
 
         for (let i = 0; i < collatorGroup.count; i++) {
           let node: NodeConfig = {

--- a/src/configGenerator.ts
+++ b/src/configGenerator.ts
@@ -292,6 +292,7 @@ export async function generateNetworkSpec(
         ...(computedStateCommand
           ? { genesisStateGenerator: computedStateCommand }
           : {}),
+        ...(parachain.genesis ? { genesis: parachain.genesis} : {}),
       };
 
       networkSpec.parachains.push(parachainSetup);

--- a/src/network.ts
+++ b/src/network.ts
@@ -272,9 +272,15 @@ export class Network {
     return node;
   }
 
-  getNodesInGroup(nodeName: string): NetworkNode[] {
-    const nodes = this.groups[nodeName];
-    if (!nodes) throw new Error(`GROUP: ${nodeName} not present`);
+  getNodes(nodeOrGroupName: string): NetworkNode[] {
+    //check if is a node
+    const node = this.nodesByName[nodeOrGroupName];
+    if(node) return [node]
+
+    //check if is a group
+    const nodes = this.groups[nodeOrGroupName];
+
+    if (!nodes) throw new Error(`Noode or Group: ${nodeOrGroupName} not present`);
     return nodes;
   }
 

--- a/src/paras.ts
+++ b/src/paras.ts
@@ -9,6 +9,7 @@ import { getClient } from "./providers/client";
 import { Providers } from "./providers";
 import { fileMap, Node, Parachain } from "./types";
 import fs from "fs";
+import { changeGenesisConfig } from "./chain-spec";
 const debug = require("debug")("zombie::paras");
 
 export async function generateParachainFiles(
@@ -63,6 +64,9 @@ export async function generateParachainFiles(
     if( plainData.genesis.runtime.parachainInfo?.parachainId) plainData.genesis.runtime.parachainInfo.parachainId  = parachain.id;
     const data = JSON.stringify(plainData, null, 2);
     fs.writeFileSync(chainSpecFullPathPlain, data);
+
+    // customize if needed
+    if(parachain.genesis) await changeGenesisConfig(chainSpecFullPathPlain, parachain.genesis);
 
     debug("creating chain spec raw");
     // generate the raw chain spec

--- a/src/providers/k8s/dynResourceDefinition.ts
+++ b/src/providers/k8s/dynResourceDefinition.ts
@@ -10,7 +10,7 @@ import {
   DEFAULT_COMMAND,
 } from "../../constants";
 import { getUniqueName } from "../../configGenerator";
-import { Node } from "../../types";
+import { MultiAddressByNode, Node } from "../../types";
 import { getSha256 } from "../../utils/misc-utils";
 
 export async function genBootnodeDef(
@@ -195,6 +195,25 @@ function jaegerAgentDef() {
         "cpu": "100m"
       }
     }
+  }
+}
+
+export function replaceMultiAddresReferences(podDef: any, multiAddressByNode: MultiAddressByNode) {
+  // replace command if needed in containers
+  for( const container of podDef.spec.containers) {
+    if(Array.isArray(container.command)){
+      const finalCommand = container.command.map((item: string) => {
+        return item.replace(/{{ZOMBIE:(.*?)?}}/ig, (_substring, nodeName) => {
+          return multiAddressByNode[nodeName];
+        });
+      });
+      container.command = finalCommand;
+    } else {
+      container.command = container.command.replace(/{{ZOMBIE:(.*?)?}}/ig, (_substring: any, nodeName: string) => {
+        return multiAddressByNode[nodeName];
+      });
+    }
+
   }
 }
 

--- a/src/providers/k8s/index.ts
+++ b/src/providers/k8s/index.ts
@@ -1,5 +1,5 @@
 import { KubeClient, initClient } from "./kubeClient";
-import { genBootnodeDef, genNodeDef } from "./dynResourceDefinition";
+import { genBootnodeDef, genNodeDef, replaceMultiAddresReferences } from "./dynResourceDefinition";
 import { setupChainSpec, getChainSpecRaw } from "./chain-spec";
 
 export const provider = {
@@ -9,4 +9,5 @@ export const provider = {
   initClient,
   setupChainSpec,
   getChainSpecRaw,
+  replaceMultiAddresReferences,
 };

--- a/src/providers/native/dynResourceDefinition.ts
+++ b/src/providers/native/dynResourceDefinition.ts
@@ -7,7 +7,7 @@ import {
   DEFAULT_COMMAND,
 } from "../../constants";
 import { getUniqueName } from "../../configGenerator";
-import { Node } from "../../types";
+import { MultiAddressByNode, Node } from "../../types";
 import { getRandomPort } from "../../utils/net-utils";
 import { getClient } from "../client";
 
@@ -127,6 +127,23 @@ async function getPorts() {
   ];
 
   return ports;
+}
+
+export function replaceMultiAddresReferences(podDef: any, multiAddressByNode: MultiAddressByNode) {
+  // replace command if needed
+  if(Array.isArray(podDef.spec.command)) {
+    const finalCommand = podDef.spec.command.map((item: string) => {
+      return item.replace(/{{ZOMBIE:(.*?)?}}/ig, (_substring, nodeName) => {
+        return multiAddressByNode[nodeName];
+      });
+    });
+    podDef.spec.command = finalCommand;
+  } else {
+    // string
+    podDef.spec.command = podDef.spec.command.replace(/{{ZOMBIE:(.*?)?}}/ig, (_substring: any, nodeName: string) => {
+        return multiAddressByNode[nodeName];
+      });
+  }
 }
 
 function getPortFlags(ports: any): { [flag: string]: number } {

--- a/src/providers/native/index.ts
+++ b/src/providers/native/index.ts
@@ -1,5 +1,5 @@
 import { NativeClient, initClient } from "./nativeClient";
-import { genBootnodeDef, genNodeDef } from "./dynResourceDefinition";
+import { genBootnodeDef, genNodeDef, replaceMultiAddresReferences } from "./dynResourceDefinition";
 import { setupChainSpec, getChainSpecRaw } from "./chain-spec";
 
 export const provider = {
@@ -9,4 +9,5 @@ export const provider = {
   initClient,
   setupChainSpec,
   getChainSpecRaw,
+  replaceMultiAddresReferences
 };

--- a/src/providers/podman/index.ts
+++ b/src/providers/podman/index.ts
@@ -1,5 +1,5 @@
 import { PodmanClient, initClient } from "./podmanClient";
-import { genBootnodeDef, genNodeDef } from "./dynResourceDefinition";
+import { genBootnodeDef, genNodeDef, replaceMultiAddresReferences } from "./dynResourceDefinition";
 import { setupChainSpec, getChainSpecRaw } from "./chain-spec";
 
 export const provider = {
@@ -9,4 +9,5 @@ export const provider = {
   initClient,
   setupChainSpec,
   getChainSpecRaw,
+  replaceMultiAddresReferences,
 };

--- a/src/test-runner/index.ts
+++ b/src/test-runner/index.ts
@@ -320,7 +320,7 @@ function parseAssertionLine(assertion: string) {
     if (m[4]) t = parseInt(m[4], 10);
     return async (network: Network) => {
       const timeout: number|undefined = t;
-      const nodes = network.getNodesInGroup(nodeName);
+      const nodes = network.getNodes(nodeName);
       const results = await Promise.all(nodes.map(node => node.getMetric("process_start_time_seconds", null, timeout)));
       const AllNodeUps = results.every(Boolean);
       expect(AllNodeUps).to.be.ok;

--- a/src/test-runner/index.ts
+++ b/src/test-runner/index.ts
@@ -285,7 +285,7 @@ function parseAssertionLine(assertion: string) {
 
     return async (network: Network) => {
       const timeout: number|undefined = t;
-      const nodes = network.getNodesInGroup(nodeName);
+      const nodes = network.getNodes(nodeName);
       const results = await Promise.all(nodes.map(node => node.parachainIsRegistered(parachainId, timeout)));
 
       const parachainIsRegistered = results.every(Boolean);
@@ -304,7 +304,7 @@ function parseAssertionLine(assertion: string) {
 
     return async (network: Network) => {
       const timeout: number|undefined = t;
-      const nodes = network.getNodesInGroup(nodeName);
+      const nodes = network.getNodes(nodeName);
 
       const results = await Promise.all(nodes.map(node => node.parachainBlockHeight(parachainId, targetValue, timeout)));
       for( const value of results) {
@@ -317,7 +317,7 @@ function parseAssertionLine(assertion: string) {
   if (m && m[1] !== null) {
     const nodeName = m[1];
     return async (network: Network) => {
-      const nodes = network.getNodesInGroup(nodeName);
+      const nodes = network.getNodes(nodeName);
       const results = await Promise.all(nodes.map(node => node.getMetric("process_start_time_seconds")));
       const AllNodeUps = results.every(Boolean);
       expect(AllNodeUps).to.be.ok;
@@ -335,7 +335,7 @@ function parseAssertionLine(assertion: string) {
     if (m[8]) t = parseInt(m[8], 10);
     return async (network: Network, backchannelMap: BackchannelMap) => {
       const timeout: number|undefined = t;
-      const nodes = network.getNodesInGroup(nodeName);
+      const nodes = network.getNodes(nodeName);
       const results = await Promise.all(nodes.map(node => node.getHistogramSamplesInBuckets(metricName, buckets, targetValue, timeout)));
 
       for( const value of results) {
@@ -354,7 +354,7 @@ function parseAssertionLine(assertion: string) {
     if (m[8]) t = parseInt(m[8], 10);
     return async (network: Network, backchannelMap: BackchannelMap) => {
       const _timeout: number|undefined = t;
-      const nodes = network.getNodesInGroup(nodeName);
+      const nodes = network.getNodes(nodeName);
       const results = await Promise.all(nodes.map(node => node.getSpansByTraceId(traceId, network.tracingCollatorUrl!)));
 
       for(const value of results) {
@@ -373,7 +373,7 @@ function parseAssertionLine(assertion: string) {
     if (m[7]) t = parseInt(m[7], 10);
     return async (network: Network, backchannelMap: BackchannelMap) => {
       const timeout: number|undefined = t;
-      const nodes = network.getNodesInGroup(nodeName);
+      const nodes = network.getNodes(nodeName);
       const results = await Promise.all(nodes.map(node => node.getMetric(metricName, targetValue, timeout)));
 
       for( const value of results) {
@@ -392,7 +392,7 @@ function parseAssertionLine(assertion: string) {
 
     return async (network: Network) => {
       const timeout: number|undefined = t;
-      const nodes = network.getNodesInGroup(nodeName);
+      const nodes = network.getNodes(nodeName);
       const results = await Promise.all(nodes.map(node => node.findPattern(pattern, isGlob, timeout)));
 
       const found = results.every(Boolean);
@@ -549,7 +549,7 @@ function parseAssertionLine(assertion: string) {
     if (m[4]) t = parseInt(m[4], 10);
     return async (network: Network, backchannelMap: BackchannelMap) => {
       const timeout: number|undefined = t;
-      const nodes = network.getNodesInGroup(nodeName);
+      const nodes = network.getNodes(nodeName);
       const results = await Promise.all(nodes.map(node => node.restart(timeout)));
 
       const restarted = results.every(Boolean);
@@ -561,7 +561,7 @@ function parseAssertionLine(assertion: string) {
   if (m && m[2]) {
     const nodeName = m[2];
     return async (network: Network, backchannelMap: BackchannelMap) => {
-      const nodes = network.getNodesInGroup(nodeName);
+      const nodes = network.getNodes(nodeName);
       const results = await Promise.all(nodes.map(node => node.pause()));
 
       const paused = results.every(Boolean);

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -85,6 +85,7 @@ export interface ParachainConfig {
   collator?: NodeConfig;
   collators?: NodeConfig[];
   collator_groups?: NodeGroupConfig[];
+  genesis?: JSON | ObjectJSON;
 }
 
 export interface HrmpChannelsConfig {
@@ -166,6 +167,7 @@ export interface Parachain {
   specPath?: string;
   balance?: number;
   collators: Node[];
+  genesis?: JSON | ObjectJSON
 }
 
 export interface envVars {

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -81,22 +81,8 @@ export interface ParachainConfig {
   genesis_state_generator?: string;
   cumulus_based?: boolean;
   bootnodes?: string[];
-  collator?: CollatorConfig;
-  collator_groups?: CollatorGroupConfig[];
-}
-
-export interface CollatorConfig {
-  image?: string;
-  command?: string;
-  commandWithArgs?: string;
-  name?: string;
-  args?: string[];
-  env?: envVars[];
-}
-
-export interface CollatorGroupConfig {
-  collator: CollatorConfig;
-  count: number;
+  nodes?: NodeConfig[];
+  node_groups?: NodeGroupConfig[];
 }
 
 export interface HrmpChannelsConfig {
@@ -107,7 +93,6 @@ export interface HrmpChannelsConfig {
 }
 
 // Computed Network
-// T
 export interface ComputedNetwork {
   settings: Settings;
   relaychain: {
@@ -241,4 +226,8 @@ export interface Resources {
       cpu?: string;
     };
   };
+}
+
+export interface MultiAddressByNode {
+  [key: string]: string;
 }

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -81,8 +81,10 @@ export interface ParachainConfig {
   genesis_state_generator?: string;
   cumulus_based?: boolean;
   bootnodes?: string[];
-  nodes?: NodeConfig[];
-  node_groups?: NodeGroupConfig[];
+  // backward compatibility
+  collator?: NodeConfig;
+  collators?: NodeConfig[];
+  collator_groups?: NodeGroupConfig[];
 }
 
 export interface HrmpChannelsConfig {

--- a/src/utils/fs-utils.ts
+++ b/src/utils/fs-utils.ts
@@ -53,6 +53,11 @@ function getReplacementInText(content: string): string[] {
 export function readNetworkConfig(filepath: string): LaunchConfig {
   const configBasePath = path.dirname(filepath);
   const env = new Environment(new RelativeLoader([configBasePath]));
+
+  env.addFilter('zombie', function(nodeName){
+    return `{{ZOMBIE:${nodeName}}}`;
+  });
+
   const temmplateContent = fs.readFileSync(filepath).toString();
   const content = env.renderString(temmplateContent, process.env);
 


### PR DESCRIPTION
- Add `collators` and use the `NodeConfig` to set those.
- Allow to run collators without the `--collator` flag.
- Expose collators prometheus metrics.
- Add `multiAddressByNode` allowing to make references between nodes in the network spec using the `zombie` filter

   ```
     # run eve as parachain full node that is only connected to dave
    [[parachains.collators]]
    name = "eve"
    validator = false
    image = "docker.io/parity/polkadot-collator:latest"
    command = "test-collator"
    args = ["--reserved-only", "--reserved-nodes {{'dave'|zombie}}"]
    ```

Needs this [PR](https://github.com/skunert/cumulus/pull/19) and an image to test in k8s/podman.
  