### PR TITLE
set skipLibCheck to true in tsconfig.json

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "module": "commonjs",
     "lib": ["esnext"],
     "outDir": "dist",
+    "skipLibCheck": true,
     "resolveJsonModule": true,
     "strict": true,
     "declaration": true,


### PR DESCRIPTION
I've noticed that tsconfig.json missing skipLibCheck. It causes build to fail because of some type mismatch in node_modules. Adding this flag to the config fixes the problem

<img width="735" alt="Снимок экрана 2022-05-06 в 14 14 25" src="https://user-images.githubusercontent.com/16861579/167077097-d9063439-b402-4edd-a4df-dcf83fa89bc1.png">
