### PR TITLE
Fix wait message to check if node is up

### DIFF
--- a/src/providers/native/nativeClient.ts
+++ b/src/providers/native/nativeClient.ts
@@ -277,7 +277,7 @@ export class NativeClient extends Client {
     let t = this.timeout;
     const args = [
       "-c",
-      `grep 'Listening for new connections'  ${logFile} | wc -l`,
+      `grep -E 'Running JSON-RPC WS server|Listening for new connections'  ${logFile} | wc -l`,
     ];
     do {
       const result = await this.runCommand(args);


### PR DESCRIPTION
I am using the `native` provider locally and was wondering why node start is not being detected. Turns out the logs do not print `Listening for new connections` anymore as of recently.