### PR TITLE
changes to support chain upgrade from local fs

### DIFF
--- a/src/jsapi-helpers/index.ts
+++ b/src/jsapi-helpers/index.ts
@@ -1,6 +1,7 @@
 import { ApiPromise, WsProvider } from "@polkadot/api";
 import {
-  chainUpgrade,
+  chainUpgradeFromLocalFile,
+  chainUpgradeFromUrl,
   chainCustomSectionUpgrade,
   validateRuntimeCode,
 } from "./chain-upgrade";
@@ -16,7 +17,8 @@ async function connect(apiUrl: string, types: any): Promise<ApiPromise> {
 
 export {
   connect,
-  chainUpgrade,
+  chainUpgradeFromLocalFile,
+  chainUpgradeFromUrl,
   chainCustomSectionUpgrade,
   validateRuntimeCode,
   paraGetBlockHeight,

--- a/src/utils/misc-utils.ts
+++ b/src/utils/misc-utils.ts
@@ -23,6 +23,17 @@ export function addMinutes(howMany: number, baseDate?: Date): [number, number] {
   return [targetDate.getUTCHours(), targetDate.getUTCMinutes()];
 }
 
+export function isValidHttpUrl(input: string) {
+  let url;
+
+  try {
+    url = new URL(input);
+  } catch (_) {
+    return false;
+  }
+
+  return url.protocol === "http:" || url.protocol === "https:";
+}
 export function filterConsole(excludePatterns: string[], options?: any) {
   options = {
     console,


### PR DESCRIPTION
- Allow to pass a relative/absolute path to `wasm` to use in the chainUpgrade assertion.

```
alice: parachain 100 perform upgrade with <url | file> within 200 seconds
```