### PR TITLE
add convertExp fn to works with substrate 1e+21 balances

### DIFF
--- a/src/chain-spec.ts
+++ b/src/chain-spec.ts
@@ -2,6 +2,7 @@ import { encodeAddress } from "@polkadot/util-crypto";
 import { decorators } from "./utils/colors";
 import { ChainSpec, HrmpChannelsConfig } from "./types";
 import { readDataFile } from "./utils/fs-utils";
+import { convertExponentials } from "./utils/misc-utils";
 const fs = require("fs");
 const debug = require("debug")("zombie::chain-spec");
 
@@ -282,7 +283,7 @@ function readAndParseChainSpec(specPath: string) {
 function writeChainSpec(specPath: string, chainSpec: any) {
   try {
     let data = JSON.stringify(chainSpec, null, 2);
-    fs.writeFileSync(specPath, data);
+    fs.writeFileSync(specPath, convertExponentials(data));
   } catch {
     console.error(
       `\n\t\t  ${decorators.red("  ⚠ failed to write the chain spec with path: ")} ${specPath}`

--- a/src/utils/misc-utils.ts
+++ b/src/utils/misc-utils.ts
@@ -70,3 +70,12 @@ export function filterConsole(excludePatterns: string[], options?: any) {
     }
   };
 }
+
+// convert 1e+X (e.g 1e+21) to literal
+export function convertExponentials(data: string): string {
+  const converted = data.replace(/e\+[0-9]+/ig, function(exp) {
+    const e = parseInt(exp.split("+")[1],10);
+    return "0".repeat(e);
+  });
+  return converted;
+}


### PR DESCRIPTION
Fix balances' notations on chain-spec (e.g substrate 1e+21).

cc @hbulgarini 