### PR TITLE
Fix setting the provider via file

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,7 +8,11 @@ import { getCredsFilePath, readNetworkConfig } from "./utils/fs-utils";
 import { LaunchConfig } from "./types";
 import { run } from "./test-runner";
 import { Command, Option } from "commander";
-import { AVAILABLE_PROVIDERS, DEFAULT_GLOBAL_TIMEOUT } from "./constants";
+import {
+  AVAILABLE_PROVIDERS,
+  DEFAULT_GLOBAL_TIMEOUT,
+  DEFAULT_PROVIDER,
+} from "./constants";
 import { decorators } from "./utils/colors";
 
 const debug = require("debug")("zombie-cli");
@@ -82,7 +86,6 @@ program
   .addOption(
     new Option("-p, --provider <provider>", "Override provider to use")
       .choices(["podman", "kubernetes", "native"])
-      .default("kubernetes", "kubernetes")
   )
   .addOption(
     new Option("-m, --monitor", "Start as monitor, do not auto cleanup network")
@@ -131,14 +134,14 @@ async function spawn(
 
   // if a provider is passed, let just use it.
   if (opts.provider && AVAILABLE_PROVIDERS.includes(opts.provider)) {
-    if (!config.settings) {
-      config.settings = {
-        provider: opts.provider,
-        timeout: DEFAULT_GLOBAL_TIMEOUT,
-      };
-    } else {
-      config.settings.provider = opts.provider;
-    }
+    config.settings.provider = opts.provider;
+  }
+  // set default provider and timeout if not provided
+  if (!config.settings.provider) {
+    config.settings.provider = DEFAULT_PROVIDER;
+  }
+  if (!config.settings.timeout) {
+    config.settings.timeout = DEFAULT_GLOBAL_TIMEOUT;
   }
 
   let creds = "";

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -61,6 +61,7 @@ export const LOKI_URL_FOR_NODE =
   "https://grafana.parity-mgmt.parity.io/explore?orgId=1&left=%5B%22now-3h%22,%22now%22,%22loki.parity-zombienet%22,%7B%22expr%22:%22%7Bpod%3D~%5C%22{{namespace}}%2F{{podName}}%5C%22%7D%22,%22refId%22:%22A%22,%22range%22:true%7D%5D";
 
 export const AVAILABLE_PROVIDERS = ["podman", "kubernetes", "native"];
+export const DEFAULT_PROVIDER = "kubernetes";
 export const DEV_ACCOUNTS = [
   "alice",
   "bob",


### PR DESCRIPTION
By setting a default for the `--provider` cli argument and allowing the `--provider` cli argument to override the config setting if present, it is impossible to set the provider via config since a value will always be available for the `--provider` cli argument.

This chain breaks a nested if statement into two specific pieces:
1. If the `--provider` cli argument is provided, override the config setting
2. If config is missing for provider or timeout, use the default values.

## Notes

This changes the condition when `DEFAULT_GLOBAL_TIMEOUT` is set. Previously, it was only set when `--provider` was provided and `config.settings` was empty. With this change, `DEFAULT_GLOBAL_TIMEOUT` will be set whenever `config.settings.timeout` is not set. 