### PR TITLE
Create Setup process

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ Other examples are provided in the [examples](examples) directory.
 
 ## Development
 
-### Requerimients
+### Requirements
 
 - [Node.js](https://nodejs.org/)
 - kubernetes cluster to use as target
@@ -274,6 +274,33 @@ cd zombienet
 npm install
 npm run build
 ```
+
+### Download and install needed artifacts (Optional)
+
+For easier and faster setup of local environment, upi can run:
+
+```bash
+❯ node dist/setup.js
+
+Setup is meant for downloading and making everything ready for dev environment of ZombieNet;
+
+You can use the following arguments:
+
+--help shows this message;
+--binaries or -b: the binaries that you want to be downloaded and installed during the setup, provided in a row without any separators;
+	possible options: 'polkadot', 'parachain'
+	example: node dist/setup.js -b polkadot parachain
+```
+
+Script above will retrieve the binaries provided and try to download and prepare those binaries for usage. At the end of the download, script will provide a command to run in your local environment in order to add the directory where the binaries were downloaded in your $PATH var:
+
+e.g.
+
+```bash
+Please add the dir to your $PATH by running the command: export PATH=/home/<user>/zombienet/dist:$PATH
+```
+
+### Run ZombieNet
 
 Then `zombienet` cli is ready to run:
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Also, you need *permission* to create resources (e.g `namespaces`, `pods` and `c
 
 #### Using `Zombienet` GKE cluster (internally).
 
-Zombienet project has it's own k8s cluster in GCP, to use it please ping [Javier](@javier:matrix.parity.io) in element to gain access and steps to use.
+Zombienet project has it's own k8s cluster in GCP, to use it please ping <b>Javier</b>(@javier:matrix.parity.io) in element to gain access and steps to use.
 
 ### With Podman
 

--- a/docs/src/development.md
+++ b/docs/src/development.md
@@ -9,13 +9,40 @@
 
 ## Installation
 
-You need first to *clone* this repository and run:
+You need first to _clone_ this repository and run:
 
 ```bash
 cd zombienet
 npm install
 npm run build
 ```
+
+### Download and install needed artifacts (Optional)
+
+For easier and faster setup of local environment, upi can run:
+
+```bash
+❯ node dist/setup.js
+
+Setup is meant for downloading and making everything ready for dev environment of ZombieNet;
+
+You can use the following arguments:
+
+--help shows this message;
+--binaries or -b: the binaries that you want to be downloaded and installed during the setup, provided in a row without any separators;
+	possible options: 'polkadot', 'parachain'
+	example: node dist/setup.js -b polkadot parachain
+```
+
+Script above will retrieve the binaries provided and try to download and prepare those binaries for usage. At the end of the download, script will provide a command to run in your local environment in order to add the directory where the binaries were downloaded in your $PATH var:
+
+e.g.
+
+```bash
+Please add the dir to your $PATH by running the command: export PATH=/home/<user>/zombienet/dist:$PATH
+```
+
+### Using Zombienet
 
 Then `zombienet` cli is ready to run:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "napi-maybe-compressed-blob": "0.0.2",
         "nunjucks": "^3.2.3",
         "peer-id": "^0.16.0",
+        "progress": "^2.0.3",
         "tmp-promise": "^3.0.2",
         "toml": "^3.0.0",
         "yaml": "^2.0.0-9"
@@ -39,6 +40,7 @@
         "@types/mocha": "^9.0.0",
         "@types/node": "^16.4.12",
         "@types/nunjucks": "^3.2.1",
+        "@types/progress": "^2.0.5",
         "@types/tmp": "^0.2.1",
         "pkg": "~5.5.1",
         "prettier": "2.2.1",
@@ -837,6 +839,15 @@
       "resolved": "https://registry.npmjs.org/@types/parse5/-/parse5-6.0.3.tgz",
       "integrity": "sha512-SuT16Q1K51EAVPz1K29DJ/sXjhSQ0zjvsypYJ6tlwVsRV9jwW5Adq2ch8Dq8kDBCkYnELS7N7VNCSB5nC56t/g==",
       "dev": true
+    },
+    "node_modules/@types/progress": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/progress/-/progress-2.0.5.tgz",
+      "integrity": "sha512-ZYYVc/kSMkhH9W/4dNK/sLNra3cnkfT2nJyOAIDY+C2u6w72wa0s1aXAezVtbTsnN8HID1uhXCrLwDE2ZXpplg==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/tmp": {
       "version": "0.2.1",
@@ -2856,15 +2867,6 @@
         "semver": "^5.4.1"
       }
     },
-    "node_modules/node-abi/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
     "node_modules/node-fetch": {
       "version": "2.6.7",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
@@ -3301,7 +3303,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
-      "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -3538,6 +3539,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver"
       }
     },
     "node_modules/serialize-javascript": {
@@ -4877,6 +4887,15 @@
       "resolved": "https://registry.npmjs.org/@types/parse5/-/parse5-6.0.3.tgz",
       "integrity": "sha512-SuT16Q1K51EAVPz1K29DJ/sXjhSQ0zjvsypYJ6tlwVsRV9jwW5Adq2ch8Dq8kDBCkYnELS7N7VNCSB5nC56t/g==",
       "dev": true
+    },
+    "@types/progress": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/progress/-/progress-2.0.5.tgz",
+      "integrity": "sha512-ZYYVc/kSMkhH9W/4dNK/sLNra3cnkfT2nJyOAIDY+C2u6w72wa0s1aXAezVtbTsnN8HID1uhXCrLwDE2ZXpplg==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/tmp": {
       "version": "0.2.1",
@@ -6358,14 +6377,6 @@
       "dev": true,
       "requires": {
         "semver": "^5.4.1"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-          "dev": true
-        }
       }
     },
     "node-fetch": {
@@ -6672,8 +6683,7 @@
     "progress": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
-      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
-      "dev": true
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="
     },
     "propagate": {
       "version": "2.0.1",
@@ -6840,6 +6850,12 @@
       "requires": {
         "xmlchars": "^2.2.0"
       }
+    },
+    "semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true
     },
     "serialize-javascript": {
       "version": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
   "scripts": {
     "clean": "rm -rf ./dist/*",
     "build": "tsc",
-    "start": "yarn build && node dist/cli.js",
     "lint": "npx prettier --write ./src",
     "package": "pkg . --out-path ./bins"
   },
@@ -37,6 +36,7 @@
     "napi-maybe-compressed-blob": "0.0.2",
     "nunjucks": "^3.2.3",
     "peer-id": "^0.16.0",
+    "progress": "^2.0.3",
     "tmp-promise": "^3.0.2",
     "toml": "^3.0.0",
     "yaml": "^2.0.0-9"
@@ -71,6 +71,7 @@
     "@types/mocha": "^9.0.0",
     "@types/node": "^16.4.12",
     "@types/nunjucks": "^3.2.1",
+    "@types/progress": "^2.0.5",
     "@types/tmp": "^0.2.1",
     "pkg": "~5.5.1",
     "prettier": "2.2.1",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -44,8 +44,7 @@ process.on("unhandledRejection", async (err) => {
     await network.stop();
   }
   debug(err);
-  console.log(`unhandledRejection`);
-  console.log(err);
+  console.log(`UnhandledRejection: ${err}`);
   process.exit(1001);
 });
 
@@ -161,6 +160,9 @@ async function spawn(
   if (config.settings?.provider === "kubernetes") {
     creds = getCredsFilePath(credsFile || "config") || "";
     if (!creds) {
+      console.log(
+        `Running ${config.settings?.provider || DEFAULT_PROVIDER} provider:`,
+      );
       console.error("  ⚠ I can't find the Creds file: ", credsFile);
       process.exit();
     }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -11,14 +11,6 @@ export const RPC_HTTP_PORT = 9944;
 // The port substrate listens for p2p connections on
 export const P2P_PORT = 30333;
 
-// Paths for downloading the binaries for zombienet setup
-export const DEFAULT_COMMAND_URL =
-  "https://github.com/paritytech/polkadot/releases/download/v0.9.27/polkadot";
-export const DEFAULT_ADDER_COLLATOR_URL =
-  "https://gitlab.parity.io/parity/mirrors/polkadot/-/jobs/1769497/artifacts/raw/artifacts/adder-collator";
-export const DEFAULT_CUMULUS_COLLATOR_URL =
-  "https://github.com/paritytech/cumulus/releases/download/v0.9.230/polkadot-parachain";
-
 export const DEFAULT_GLOBAL_TIMEOUT = 1200; // 20 mins
 export const DEFAULT_INDIVIDUAL_TEST_TIMEOUT = 10; // seconds
 export const DEFAULT_COMMAND = "polkadot";

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -11,6 +11,14 @@ export const RPC_HTTP_PORT = 9944;
 // The port substrate listens for p2p connections on
 export const P2P_PORT = 30333;
 
+// Paths for downloading the binaries for zombienet setup
+export const DEFAULT_COMMAND_URL =
+  "https://github.com/paritytech/polkadot/releases/download/v0.9.27/polkadot";
+export const DEFAULT_ADDER_COLLATOR_URL =
+  "https://gitlab.parity.io/parity/mirrors/polkadot/-/jobs/1769497/artifacts/raw/artifacts/adder-collator";
+export const DEFAULT_CUMULUS_COLLATOR_URL =
+  "https://github.com/paritytech/cumulus/releases/download/v0.9.230/polkadot-parachain";
+
 export const DEFAULT_GLOBAL_TIMEOUT = 1200; // 20 mins
 export const DEFAULT_INDIVIDUAL_TEST_TIMEOUT = 10; // seconds
 export const DEFAULT_COMMAND = "polkadot";

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -77,9 +77,9 @@ const downloadBinaries = async (binaries: string[]): Promise<void> => {
         data.on("data", (chunk: any) => progressBar.tick(chunk.length));
         data.pipe(writer);
         data.on("end", () => {
-          console.log(dec("yellow", `Binary ${name} downloaded`));
+          console.log(dec("yellow", `Binary "${name}" downloaded`));
           // Add permissions to the binary
-          console.log(dec("cyan", `Giving permissions to ${name}`));
+          console.log(dec("cyan", `Giving permissions to "${name}"`));
           fs.chmodSync(path.resolve(__dirname, name), 0o755);
           resolve();
         });
@@ -89,6 +89,7 @@ const downloadBinaries = async (binaries: string[]): Promise<void> => {
   await Promise.all(promises);
   console.log(
     dec("cyan", `Please add the dir to your $PATH by running the command:`),
+    "\n",
     dec("blue", `export PATH=${__dirname}:$PATH`),
   );
 };
@@ -150,5 +151,7 @@ const execute = async () => {
   }
 };
 
-console.log(`\n🧟🧟🧟 ${dec("green", "ZombieNet dev setup ")}🧟🧟🧟\n`);
+console.log(
+  `\n🧟🧟🧟 ${dec("green", "ZombieNet dev environment setup ")}🧟🧟🧟\n`,
+);
 execute();

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -104,7 +104,7 @@ const howTo = () => {
     `${dec(
       "yellow",
       "--binaries or -b:",
-    )} the binaries that you want to be downloaded and installed during the setup, provided in a row without any separators;`,
+    )} the binaries that you want to be downloaded, provided in a row without any separators; They are downloaded in 'dist' directory and appropriate executable permissions are assigned.`,
   );
   msg.push(`\tpossible options: ${dec("cyan", "'polkadot', 'parachain'")}`);
   msg.push(

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -1,0 +1,155 @@
+import readline from "readline";
+import {
+  DEFAULT_COMMAND_URL,
+  DEFAULT_CUMULUS_COLLATOR_URL,
+  // DEFAULT_ADDER_COLLATOR_URL,
+} from "./constants";
+import { decorators } from "./utils/colors";
+import fs from "fs";
+import { exec } from "child_process";
+import path from "path";
+import axios from "axios";
+import progress from "progress";
+
+const polkadot = DEFAULT_COMMAND_URL;
+const parachain = DEFAULT_CUMULUS_COLLATOR_URL;
+// This will be activated once the binary is ready
+// const collator = DEFAULT_ADDER_COLLATOR_URL;
+
+interface OptIf {
+  [key: string]: { name: string; url: string; size: string };
+}
+
+const options: OptIf = {
+  polkadot: { name: "polkadot", url: DEFAULT_COMMAND_URL, size: "131" },
+  parachain: {
+    name: "parachain",
+    url: DEFAULT_CUMULUS_COLLATOR_URL,
+    size: "117",
+  },
+};
+
+const dec = (color: string, msg: string): string => decorators[color](msg);
+
+const askQuestion = async (query: string): Promise<string> => {
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+
+  return new Promise((resolve) =>
+    rl.question(query, (ans) => {
+      rl.close();
+      resolve(ans);
+    }),
+  );
+};
+
+// Download the binaries
+const downloadBinaries = async (binaries: string[]): Promise<void> => {
+  console.log("\nStart download...\n");
+  const promises = await binaries.map(async (binary: string) => {
+    const { url, name } = options[binary];
+    // if (fs.existsSync(path.resolve(__dirname, name))) {
+    //   console.log("Binary already exists. Do you want to overwrite it? (y/n)");
+    //   const response = await askQuestion("Do you want to continue? (y/n)");
+    //   if (response.toLowerCase() !== "n" && response.toLowerCase() !== "y") {
+    //     console.log("Invalid input. Exiting...");
+    //     return;
+    //   }
+    //   if (response.toLowerCase() === "n") {
+    //     return;
+    //   }
+    // }
+    console.log(`${dec("yellow", "Connecting …")}`);
+    const { data, headers } = await axios({
+      url,
+      method: "GET",
+      responseType: "stream",
+    });
+    const totalLength = headers["content-length"];
+
+    console.log("Starting download");
+    const progressBar = new progress("-> downloading [:bar] :percent :etas", {
+      width: 40,
+      complete: "=",
+      incomplete: " ",
+      renderThrottle: 1,
+      total: parseInt(totalLength),
+    });
+
+    const writer = fs.createWriteStream(path.resolve(__dirname, name));
+
+    data.on("data", (chunk: any) => progressBar.tick(chunk.length));
+    data.pipe(writer);
+    data.on("end", () => {
+      console.log(dec("yellow", "Download finished."));
+      // Add permissions to the binary
+      console.log(dec("yellow", "Giving permissions..."));
+      fs.chmodSync(path.resolve(__dirname, name), 0o755);
+      // Add all binaries to the PATH
+      console.log(dec("yellow", "Add to PATH."));
+    });
+  });
+  await Promise.all(promises);
+};
+
+const howTo = () => {
+  const msg = [];
+  msg.push(
+    "Setup is meant for downloading and making everything ready for dev environment of ZombieNet;\n",
+  );
+  msg.push("You can use the following arguments:\n");
+  msg.push(`${dec("yellow", "--help")} shows this message;`);
+  msg.push(
+    `${dec(
+      "yellow",
+      "--binaries or -b:",
+    )} the binaries that you want to be downloaded and installed during the setup, provided in a row without any separators;`,
+  );
+  msg.push(`\tpossible options: ${dec("cyan", "'polkadot', 'parachain'")}`);
+  msg.push(
+    `\texample: ${dec("blue", "node dist/setup.js -b polkadot parachain")}`,
+  );
+  console.log(msg.join("\n"));
+};
+
+const { argv } = process;
+argv.splice(0, 2);
+
+const execute = async () => {
+  switch (argv[0]) {
+    case undefined:
+      console.error(`Error: ${dec("red", "No command specified")}`);
+      howTo();
+      break;
+    case "--help":
+    case "-h":
+      howTo();
+      break;
+    case "--binaries":
+    case "-b":
+      argv.splice(0, 1);
+      let count = 0;
+      console.log("Setup will start to download binaries:");
+      argv.forEach((a) => {
+        const size = parseInt(options[a].size, 10);
+        count += size;
+        console.log("-", a, "\t Approx. size ", size, " MB");
+      });
+      console.log("Total approx. size: ", count, "MB");
+      const response = await askQuestion("Do you want to continue? (y/n)");
+      if (response.toLowerCase() !== "n" && response.toLowerCase() !== "y") {
+        console.log("Invalid input. Exiting...");
+        break;
+      }
+      if (response.toLowerCase() === "n") {
+        break;
+      }
+      downloadBinaries(argv);
+      break;
+  }
+};
+
+console.log(`\n🧟🧟🧟 ${dec("green", "ZombieNet dev setup ")}🧟🧟🧟\n`);
+execute();


### PR DESCRIPTION
This PR creates an automated script that, setups locally the environment for running zombienet. Image below shows the outcome of the script:

![image](https://user-images.githubusercontent.com/5408605/186629201-4b24825c-5a30-49da-8932-e602dcb19622.png)

User, once finishes with cloning and building the repo, can run the command `node dist/setup.js -b <binaries>`:
This will add the binaries that user wants to be downloaded, provided in a row without any separators; They are downloaded in 'dist' directory and appropriate executable permissions are assigned. 
Possible options: `polkadot`, `parachain`. Example: `node dist/setup.js -b polkadot parachain`

`AdderCollator` also is a possible option but due to the fact that it exists only in gitlab as an artifact that seizes to exist after few days, it is not activated just yet