### PR TITLE
Reduce mergify checks

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,7 +1,7 @@
 queue_rules:
   - name: default
     conditions:
-      - check-success=[all, continuous-integration/gitlab-build, continuous-integration/gitlab-lint, continuous-integration/gitlab-package, continuous-integration/gitlab-publish-docker-pr, continuous-integration/gitlab-publish-test, continuous-integration/gitlab-test, continuous-integration/gitlab-zombienet-custom-scripts-assertion, continuous-integration/gitlab-zombienet-logs-assertion, continuous-integration/gitlab-zombienet-restart-pause-resume, continuous-integration/gitlab-zombienet-system-event-assertion]
+      - check-success=all
       - label=automerge
       - base=main
       - "#changes-requested-reviews-by=0"
@@ -10,7 +10,7 @@ queue_rules:
 pull_request_rules:
   - name: automatic merge when CI passes on main
     conditions:
-      - check-success=[all, continuous-integration/gitlab-build, continuous-integration/gitlab-lint, continuous-integration/gitlab-package, continuous-integration/gitlab-publish-docker-pr, continuous-integration/gitlab-publish-test, continuous-integration/gitlab-test, continuous-integration/gitlab-zombienet-custom-scripts-assertion, continuous-integration/gitlab-zombienet-logs-assertion, continuous-integration/gitlab-zombienet-restart-pause-resume, continuous-integration/gitlab-zombienet-system-event-assertion]
+      - check-success=all
       - label=automerge
       - base=main
       - "#changes-requested-reviews-by=0"


### PR DESCRIPTION
reduce 'check-success' to just all(build and lint) in order to verify mergify