### PR TITLE
fix regex for custom sh

### DIFF
--- a/src/test-runner/index.ts
+++ b/src/test-runner/index.ts
@@ -334,7 +334,7 @@ const assertCustomJsRegex = new RegExp(
 
 // Run command in the node
 const assertCustomShInNode = new RegExp(
-  /^([\w-]+): run (\.{0,2}\/.*\.[\w]+)( with \"[\w \,\-/]+\")?( return is (equal to|equals|=|==|greater than|>|at least|>=|lower than|<)? *(\d+))?( within (\d+) (seconds|secs|s))?$/i,
+  /^([\w-]+): run (\.{0,2}\/.*\.[\w]+)( with \"[\w \,\-\/:.]+\")?( return is (equal to|equals|=|==|greater than|>|at least|>=|lower than|<)? *(\d+))?( within (\d+) (seconds|secs|s))?$/i,
 );
 
 // Backchannel


### PR DESCRIPTION
Allow links in args, e.g

alice: run ./0002-download-polkadot-from-pr.sh with "https://gitlab.parity.io/parity/mirrors/polkadot/-/jobs/1819527/artifacts/file/artifacts/polkadot" within 200 seconds