### PR TITLE
Fix off by one error in parachain display

### DIFF
--- a/src/network.ts
+++ b/src/network.ts
@@ -360,16 +360,16 @@ export class Network {
     }
 
     for (const [paraId, parachain] of Object.entries(this.paras)) {
+      for (const node of parachain.nodes) {
+        this.showNodeInfo(node, provider, logTable);
+      }
+
       logTable.pushTo([[decorators.cyan("Parachain ID"), paraId]]);
 
       if (parachain.chainSpecPath)
         logTable.pushTo([
           [decorators.cyan("ChainSpec Path"), parachain.chainSpecPath],
         ]);
-
-      for (const node of parachain.nodes) {
-        this.showNodeInfo(node, provider, logTable);
-      }
     }
 
     if (this.companions.length) {


### PR DESCRIPTION
A word of caution: I don't know enough about the table display library to know if this is the right fix, but I'd rather submit a pull request than an issue!

I'm experiencing an off-by-one error in the display output for parachain information.  Running a basic config (truncated for brevity, full config file at https://gist.github.com/atomaka/1696faaec51e74878037837914e8c2d3):

```[settings]
provider = "native"

[relaychain]
  [[relaychain.nodes]]
  name = "alice"

  [[relaychain.nodes]]
  name = "bob"

[[parachains]]
id = 2114

  [parachains.collator]
  name = "collator2114"

[[parachains]]
id = 1999

  [parachains.collator]
  name = "collator1999"
```

My parachain information gets displayed incorrectly. The network information for parachain 1999 is displayed under the second relay node (bob) and the network information for parachain 2114 is displayed under 1999.  2114 does not have the information.  Example output:

![Screen Shot 2022-09-08 at 12 15 35](https://user-images.githubusercontent.com/650603/189173155-454925ed-9f55-456f-abbd-71639d9d2be9.png)

This commit changes ordering in the parachain display information loop and seems to resolve the issue.