### PR TITLE
Tiny adjustments of example bash in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,9 +350,9 @@ You can build it from source like this
 
 ```bash
 git clone git@github.com:paritytech/polkadot
-cd polkadot/parachain/test-parachains/adder/collator/
-cargo build
-mv ../../../../target/debug/adder-collator /home/<user>/zombienet/dist
+cd polkadot
+cargo build --profile testnet -p test-parachain-adder-collator
+export PATH=$(pwd)/target/testnet:$PATH
 ```
 
 


### PR DESCRIPTION
I thought @pepoviola's suggested improvement in https://github.com/paritytech/zombienet/pull/441 was useful since it teaches polkadot's testnet build profile and the location of polkadot's testnet collator binaries. And it's a bit prettier. Skipped the `--verbose` flag since the build output it creates looks a bit overwhelming.

Ran through it once to make sure it works.