### PR TITLE
remove initContainers from podman

### DIFF
--- a/javascript/packages/orchestrator/src/providers/podman/dynResourceDefinition.ts
+++ b/javascript/packages/orchestrator/src/providers/podman/dynResourceDefinition.ts
@@ -23,7 +23,6 @@ export async function genBootnodeDef(
 ): Promise<any> {
   const [volume_mounts, devices] = await make_volume_mounts(nodeSetup.name);
   const container = await make_main_container(nodeSetup, volume_mounts);
-  const transferContainter = make_transfer_containter();
   return {
     apiVersion: "v1",
     kind: "Pod",
@@ -41,7 +40,7 @@ export async function genBootnodeDef(
     spec: {
       hostname: "bootnode",
       containers: [container],
-      initContainers: [transferContainter],
+      initContainers: [],
       restartPolicy: "OnFailure",
       volumes: devices,
     },
@@ -339,7 +338,6 @@ export async function genNodeDef(
 ): Promise<any> {
   const [volume_mounts, devices] = await make_volume_mounts(nodeSetup.name);
   const container = await make_main_container(nodeSetup, volume_mounts);
-  const transferContainter = make_transfer_containter();
 
   return {
     apiVersion: "v1",
@@ -362,30 +360,18 @@ export async function genNodeDef(
     spec: {
       hostname: nodeSetup.name,
       containers: [container],
-      initContainers: [transferContainter],
+      initContainers: [],
       restartPolicy: "OnFailure",
       volumes: devices,
     },
   };
 }
 
-function make_transfer_containter(): any {
-  return {
-    name: TRANSFER_CONTAINER_NAME,
-    image: "docker.io/alpine",
-    imagePullPolicy: "Always",
-    volumeMounts: [{ name: "tmp-cfg", mountPath: "/cfg", readOnly: false }],
-    command: [
-      "ash",
-      "-c",
-      `until [ -f ${FINISH_MAGIC_FILE} ]; do echo waiting for tar to finish; sleep 1; done; echo copy files has finished`,
-    ],
-  };
-}
+
 async function make_volume_mounts(name: string): Promise<[any, any]> {
   const volume_mounts = [
-    { name: "tmp-cfg", mountPath: "/cfg", readOnly: false },
-    { name: "tmp-data", mountPath: "/data", readOnly: false },
+    { name: "tmp-cfg", mountPath: "/cfg:U", readOnly: false },
+    { name: "tmp-data", mountPath: "/data:U", readOnly: false },
   ];
 
   const client = getClient();

--- a/javascript/packages/orchestrator/src/providers/podman/dynResourceDefinition.ts
+++ b/javascript/packages/orchestrator/src/providers/podman/dynResourceDefinition.ts
@@ -3,13 +3,11 @@ import { resolve } from "path";
 import { genCmd, genCumulusCollatorCmd } from "../../cmdGenerator";
 import { getUniqueName } from "../../configGenerator";
 import {
-  FINISH_MAGIC_FILE,
   INTROSPECTOR_POD_NAME,
   P2P_PORT,
   PROMETHEUS_PORT,
   RPC_HTTP_PORT,
   RPC_WS_PORT,
-  TRANSFER_CONTAINER_NAME,
 } from "../../constants";
 import { Network } from "../../network";
 import { Node } from "../../types";
@@ -366,7 +364,6 @@ export async function genNodeDef(
     },
   };
 }
-
 
 async function make_volume_mounts(name: string): Promise<[any, any]> {
   const volume_mounts = [


### PR DESCRIPTION
Fix https://github.com/paritytech/zombienet/issues/257

cc @davxy 

--
Context: For podman provider we never use the initContainer and in earlier versions wasn't supported so the `yaml` was having the definition but without use it. In >3.4 init is supported, but since the podman cli wait until the pod is running we can't interact with the init as we do in `k8s`.  This pr remove the initContainers in podman since we never use it.
 