### PR TITLE
add check  before use

### DIFF
--- a/javascript/packages/orchestrator/src/paras.ts
+++ b/javascript/packages/orchestrator/src/paras.ts
@@ -86,7 +86,7 @@ export async function generateParachainFiles(
     if (plainData.para_id) plainData.para_id = parachain.id;
     if (plainData.paraId) plainData.paraId = parachain.id;
     if (plainData.relay_chain) plainData.relay_chain = relayChainSpec.id;
-    if (plainData.genesis.runtime.parachainInfo?.parachainId)
+    if (plainData.genesis.runtime?.parachainInfo?.parachainId)
       plainData.genesis.runtime.parachainInfo.parachainId = parachain.id;
 
     writeChainSpec(chainSpecFullPathPlain, plainData);


### PR DESCRIPTION
Allow to use raw files that don't have `runtime` property.

fix https://github.com/paritytech/zombienet/issues/479