### PR TITLE
Compare NPM with local versions and if any change send for publishing

### DIFF
--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -17,42 +17,27 @@ jobs:
         run: npm run build
         working-directory: "./javascript"
 
-      - name: Check if 'CLI' version has been updated
         ## using latest from original maintainer (DO NOT CHANGE)
+      - name: Check if 'CLI' version has been updated
         uses: Rober19/compare-npm-versions-ci@a38b02a14bbee73badddf83e13ebcb3e674c6df5
         id: cli_version
         with:
           path: "./javascript/packages/cli"
           npm_package_name: "@parity/zombienet"
-
       - name: Check if 'Orchestrator' version has been updated
-        ## using latest from original maintainer (DO NOT CHANGE)
         uses: Rober19/compare-npm-versions-ci@a38b02a14bbee73badddf83e13ebcb3e674c6df5
         id: orch_version
         with:
           path: "./javascript/packages/orchestrator"
           npm_package_name: "@zombienet/orchestrator"
-
       - name: Check if 'Utils' version has been updated
-        ## using latest from original maintainer (DO NOT CHANGE)
         uses: Rober19/compare-npm-versions-ci@a38b02a14bbee73badddf83e13ebcb3e674c6df5
         id: utils_version
         with:
           path: "./javascript/packages/utils"
           npm_package_name: "@zombienet/utils"
-      - name: CLI Local/NPM versions
-        if: steps.cli_version.outputs.npm_is_greater != 'true'
-        run: |
-          echo "CLI Local version is ${{ steps.cli_version.outputs.version }}. NPM version is ${{ steps.cli_version.outputs.pkg_npm_version }}."
-      - name: ORCH Local/NPM versions
-        if: steps.orch_version.outputs.npm_is_greater != 'true'
-        run: |
-          echo "ORCH Local version is ${{ steps.orch_version.outputs.version }}. NPM version is ${{ steps.orch_version.outputs.pkg_npm_version }}."
-      - name: UTILS Local/NPM versions
-        if: steps.utils_version.outputs.npm_is_greater != 'true'
-        run: |
-          echo "UTILS Local version is ${{ steps.utils_version.outputs.version }}. NPM version is ${{ steps.utils_version.outputs.pkg_npm_version }}."
 
+      # Pack and upload each package only if version is changed
       - name: Pack Utils
         if: steps.utils_version.outputs.npm_is_greater != 'true'
         run: npm pack
@@ -63,6 +48,7 @@ jobs:
         with:
           name: package
           path: "./javascript/packages/utils/*.tgz"
+
       - name: Pack orchestrator
         if: steps.orch_version.outputs.npm_is_greater != 'true'
         run: npm pack
@@ -73,6 +59,7 @@ jobs:
         with:
           name: package
           path: "./javascript/packages/orchestrator/*.tgz"
+
       - name: Pack CLI
         if: steps.cli_version.outputs.npm_is_greater != 'true'
         run: npm pack
@@ -83,6 +70,9 @@ jobs:
         with:
           name: package
           path: "./javascript/packages/cli/*.tgz"
+
+      # Reduce "traffic" between repos by calling NPM publish automation repo only if at least
+      # one package's version has changed
       - name: NPM Publish automation
         if: steps.utils_version.outputs.npm_is_greater != 'true' || steps.orch_version.outputs.npm_is_greater != 'true' || steps.cli_version.outputs.npm_is_greater != 'true'
         uses: octokit/request-action@v2.x

--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -1,7 +1,7 @@
 name: Zombienet NPM Automated Release
 on:
   push:
-    branches: [nik-check-version-change-in-ci]
+    branches: [main]
 jobs:
   publish:
     name: Build & Publish to NPM
@@ -17,55 +17,51 @@ jobs:
         run: npm run build
         working-directory: "./javascript"
 
-        ## using latest from original maintainer (DO NOT CHANGE)
       - name: Check if 'CLI' version has been updated
-        uses: Rober19/compare-npm-versions-ci@a38b02a14bbee73badddf83e13ebcb3e674c6df5
         id: cli_version
+        uses: PostHog/check-package-version@v2
         with:
           path: "./javascript/packages/cli"
-          npm_package_name: "@parity/zombienet"
       - name: Check if 'Orchestrator' version has been updated
-        uses: Rober19/compare-npm-versions-ci@a38b02a14bbee73badddf83e13ebcb3e674c6df5
         id: orch_version
+        uses: PostHog/check-package-version@v2
         with:
           path: "./javascript/packages/orchestrator"
-          npm_package_name: "@zombienet/orchestrator"
       - name: Check if 'Utils' version has been updated
-        uses: Rober19/compare-npm-versions-ci@a38b02a14bbee73badddf83e13ebcb3e674c6df5
         id: utils_version
+        uses: PostHog/check-package-version@v2
         with:
           path: "./javascript/packages/utils"
-          npm_package_name: "@zombienet/utils"
 
       # Pack and upload each package only if version is changed
       - name: Pack Utils
-        if: steps.utils_version.outputs.npm_is_greater != 'true'
+        if: steps.utils_version.outputs.committed-version > steps.utils_version.outputs.published-version
         run: npm pack
         working-directory: "./javascript/packages/utils"
       - name: Upload Utils
-        if: steps.utils_version.outputs.npm_is_greater != 'true'
+        if: steps.utils_version.outputs.committed-version > steps.utils_version.outputs.published-version
         uses: actions/upload-artifact@v3
         with:
           name: package
           path: "./javascript/packages/utils/*.tgz"
 
       - name: Pack orchestrator
-        if: steps.orch_version.outputs.npm_is_greater != 'true'
+        if: steps.orch_version.outputs.committed-version > steps.orch_version.outputs.published-version
         run: npm pack
         working-directory: "./javascript/packages/orchestrator"
       - name: Upload Orchestrator
-        if: steps.orch_version.outputs.npm_is_greater != 'true'
+        if: steps.orch_version.outputs.committed-version > steps.orch_version.outputs.published-version
         uses: actions/upload-artifact@v3
         with:
           name: package
           path: "./javascript/packages/orchestrator/*.tgz"
 
       - name: Pack CLI
-        if: steps.cli_version.outputs.npm_is_greater != 'true'
+        if: steps.cli_version.outputs.committed-version > steps.cli_version.outputs.published-version
         run: npm pack
         working-directory: "./javascript/packages/cli"
       - name: Upload CLI
-        if: steps.cli_version.outputs.npm_is_greater != 'true'
+        if: steps.cli_version.outputs.committed-version > steps.cli_version.outputs.published-version
         uses: actions/upload-artifact@v3
         with:
           name: package
@@ -74,7 +70,7 @@ jobs:
       # Reduce "traffic" between repos by calling NPM publish automation repo only if at least
       # one package's version has changed
       - name: NPM Publish automation
-        if: steps.utils_version.outputs.npm_is_greater != 'true' || steps.orch_version.outputs.npm_is_greater != 'true' || steps.cli_version.outputs.npm_is_greater != 'true'
+        if: steps.utils_version.outputs.committed-version > steps.utils_version.outputs.published-version || steps.orch_version.outputs.committed-version > steps.orch_version.outputs.published-version || steps.cli_version.outputs.committed-version > steps.cli_version.outputs.published-version
         uses: octokit/request-action@v2.x
         with:
           route: POST /repos/paritytech/npm_publish_automation/actions/workflows/publish.yml/dispatches

--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -1,7 +1,7 @@
 name: Zombienet NPM Automated Release
 on:
   push:
-    branches: [main]
+    branches: [nik-check-version-change-in-ci]
 jobs:
   publish:
     name: Build & Publish to NPM
@@ -15,27 +15,77 @@ jobs:
           node-version: "16.x"
       - name: Build NPM Package
         run: npm run build
-        # TODO: Add checks if version is same as the one published in order to trigger the flow
         working-directory: "./javascript"
-      - run: npm pack
+
+      - name: Check if 'CLI' version has been updated
+        ## using latest from original maintainer (DO NOT CHANGE)
+        uses: Rober19/compare-npm-versions-ci@a38b02a14bbee73badddf83e13ebcb3e674c6df5
+        id: cli_version
+        with:
+          path: "./javascript/packages/cli"
+          npm_package_name: "@parity/zombienet"
+
+      - name: Check if 'Orchestrator' version has been updated
+        ## using latest from original maintainer (DO NOT CHANGE)
+        uses: Rober19/compare-npm-versions-ci@a38b02a14bbee73badddf83e13ebcb3e674c6df5
+        id: orch_version
+        with:
+          path: "./javascript/packages/orchestrator"
+          npm_package_name: "@zombienet/orchestrator"
+
+      - name: Check if 'Utils' version has been updated
+        ## using latest from original maintainer (DO NOT CHANGE)
+        uses: Rober19/compare-npm-versions-ci@a38b02a14bbee73badddf83e13ebcb3e674c6df5
+        id: utils_version
+        with:
+          path: "./javascript/packages/utils"
+          npm_package_name: "@zombienet/utils"
+      - name: CLI Local/NPM versions
+        if: steps.cli_version.outputs.npm_is_greater != 'true'
+        run: |
+          echo "CLI Local version is ${{ steps.cli_version.outputs.version }}. NPM version is ${{ steps.cli_version.outputs.pkg_npm_version }}."
+      - name: ORCH Local/NPM versions
+        if: steps.orch_version.outputs.npm_is_greater != 'true'
+        run: |
+          echo "ORCH Local version is ${{ steps.orch_version.outputs.version }}. NPM version is ${{ steps.orch_version.outputs.pkg_npm_version }}."
+      - name: UTILS Local/NPM versions
+        if: steps.utils_version.outputs.npm_is_greater != 'true'
+        run: |
+          echo "UTILS Local version is ${{ steps.utils_version.outputs.version }}. NPM version is ${{ steps.utils_version.outputs.pkg_npm_version }}."
+
+      - name: Pack Utils
+        if: steps.utils_version.outputs.npm_is_greater != 'true'
+        run: npm pack
         working-directory: "./javascript/packages/utils"
-      - uses: actions/upload-artifact@v3
+      - name: Upload Utils
+        if: steps.utils_version.outputs.npm_is_greater != 'true'
+        uses: actions/upload-artifact@v3
         with:
           name: package
           path: "./javascript/packages/utils/*.tgz"
-      - run: npm pack
+      - name: Pack orchestrator
+        if: steps.orch_version.outputs.npm_is_greater != 'true'
+        run: npm pack
         working-directory: "./javascript/packages/orchestrator"
-      - uses: actions/upload-artifact@v3
+      - name: Upload Orchestrator
+        if: steps.orch_version.outputs.npm_is_greater != 'true'
+        uses: actions/upload-artifact@v3
         with:
           name: package
           path: "./javascript/packages/orchestrator/*.tgz"
-      - run: npm pack
+      - name: Pack CLI
+        if: steps.cli_version.outputs.npm_is_greater != 'true'
+        run: npm pack
         working-directory: "./javascript/packages/cli"
-      - uses: actions/upload-artifact@v3
+      - name: Upload CLI
+        if: steps.cli_version.outputs.npm_is_greater != 'true'
+        uses: actions/upload-artifact@v3
         with:
           name: package
           path: "./javascript/packages/cli/*.tgz"
-      - uses: octokit/request-action@v2.x
+      - name: NPM Publish automation
+        if: steps.utils_version.outputs.npm_is_greater != 'true' || steps.orch_version.outputs.npm_is_greater != 'true' || steps.cli_version.outputs.npm_is_greater != 'true'
+        uses: octokit/request-action@v2.x
         with:
           route: POST /repos/paritytech/npm_publish_automation/actions/workflows/publish.yml/dispatches
           ref: main


### PR DESCRIPTION
Update CI in order to compare local versions with the ones in NPM, and call npm publish automation repo only if versions match

Look at [this example](https://github.com/paritytech/zombienet/actions/runs/3308887573/jobs/5461591211) of how GA will react when no version changes 