### PR TITLE
Add dir and force options in CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,8 @@ Options:
   -c, --spawn-concurrency <concurrency>  Number of concurrent spawning process to launch, default is 1
   -p, --provider <provider>              Override provider to use (choices: "podman", "kubernetes", "native")
                                          default: kubernetes
+  -d, --dir <path>                       Directory path for placing the network files instead of random temp one
+  -f, --force                            Force override all prompt commands
   -m, --monitor                          Start as monitor, do not auto cleanup network
   -h, --help                             display help for command
 

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Options:
   -c, --spawn-concurrency <concurrency>  Number of concurrent spawning process to launch, default is 1
   -p, --provider <provider>              Override provider to use (choices: "podman", "kubernetes", "native")
                                          default: kubernetes
-  -d, --dir <path>                       Directory path for placing the network files instead of random temp one
+  -d, --dir <path>                       Directory path for placing the network files instead of random temp one (e.g. -d /home/user/my-zombienet)
   -f, --force                            Force override all prompt commands
   -m, --monitor                          Start as monitor, do not auto cleanup network
   -h, --help                             display help for command

--- a/docs/src/cli/index.md
+++ b/docs/src/cli/index.md
@@ -9,6 +9,8 @@ Usage: zombienet [options] [command]
 Options:
   -c, --spawn-concurrency <concurrency>  Number of concurrent spawning process to launch, default is 1
   -p, --provider <provider>              Override provider to use (choices: "podman","kubernetes", "native", default: kubernetes)
+  -d, --dir <path>                       Directory path for placing the network files instead of random temp one
+  -f, --force                            Force override all prompt commands
   -m, --monitor                          Start as monitor, do not auto cleanup network
   -h, --help                             display help for command
 

--- a/docs/src/cli/index.md
+++ b/docs/src/cli/index.md
@@ -9,7 +9,7 @@ Usage: zombienet [options] [command]
 Options:
   -c, --spawn-concurrency <concurrency>  Number of concurrent spawning process to launch, default is 1
   -p, --provider <provider>              Override provider to use (choices: "podman","kubernetes", "native", default: kubernetes)
-  -d, --dir <path>                       Directory path for placing the network files instead of random temp one
+  -d, --dir <path>                       Directory path for placing the network files instead of random temp one (e.g. -d /home/user/my-zombienet)
   -f, --force                            Force override all prompt commands
   -m, --monitor                          Start as monitor, do not auto cleanup network
   -h, --help                             display help for command

--- a/javascript/README.md
+++ b/javascript/README.md
@@ -126,6 +126,8 @@ Options:
   -c, --spawn-concurrency <concurrency>  Number of concurrent spawning process to launch, default is 1
   -p, --provider <provider>              Override provider to use (choices: "podman", "kubernetes", "native")
                                          default: kubernetes
+  -d, --dir <path>                       Directory path for placing the network files instead of random temp one
+  -f, --force                            Force override all prompt commands
   -m, --monitor                          Start as monitor, do not auto cleanup network
   -h, --help                             display help for command
 

--- a/javascript/README.md
+++ b/javascript/README.md
@@ -126,7 +126,7 @@ Options:
   -c, --spawn-concurrency <concurrency>  Number of concurrent spawning process to launch, default is 1
   -p, --provider <provider>              Override provider to use (choices: "podman", "kubernetes", "native")
                                          default: kubernetes
-  -d, --dir <path>                       Directory path for placing the network files instead of random temp one
+  -d, --dir <path>                       Directory path for placing the network files instead of random temp one (e.g. -d /home/user/my-zombienet)
   -f, --force                            Force override all prompt commands
   -m, --monitor                          Start as monitor, do not auto cleanup network
   -h, --help                             display help for command

--- a/javascript/packages/cli/src/cli.ts
+++ b/javascript/packages/cli/src/cli.ts
@@ -317,7 +317,14 @@ program
       "-m, --monitor",
       "Start as monitor, do not auto cleanup network",
     ),
-  );
+  )
+  .addOption(
+    new Option(
+      "-d, --dir <path>",
+      "Directory path for placing the network files instead of random temp one",
+    ),
+  )
+  .addOption(new Option("-f, --force", "Force override all prompt commands"));
 
 program
   .command("spawn")
@@ -384,6 +391,8 @@ async function spawn(
   _opts: any,
 ) {
   const opts = program.opts();
+  const dir = opts.dir || "";
+  const force = opts.force || false;
   const monitor = opts.monitor || false;
   const spawnConcurrency = opts.spawnConcurrency || 1;
   const configPath = resolve(process.cwd(), configFile);
@@ -424,7 +433,7 @@ async function spawn(
     }
   }
 
-  const options = { monitor, spawnConcurrency };
+  const options = { monitor, spawnConcurrency, dir, force };
   network = await start(creds, config, options);
   network.showNetworkInfo(config.settings?.provider);
 }

--- a/javascript/packages/cli/src/cli.ts
+++ b/javascript/packages/cli/src/cli.ts
@@ -321,7 +321,7 @@ program
   .addOption(
     new Option(
       "-d, --dir <path>",
-      "Directory path for placing the network files instead of random temp one",
+      "Directory path for placing the network files instead of random temp one (e.g. -d /home/user/my-zombienet)",
     ),
   )
   .addOption(new Option("-f, --force", "Force override all prompt commands"));

--- a/javascript/packages/orchestrator/src/keys.ts
+++ b/javascript/packages/orchestrator/src/keys.ts
@@ -5,6 +5,7 @@ import {
   mnemonicGenerate,
   mnemonicToMiniSecret,
 } from "@polkadot/util-crypto";
+import { makeDir } from "@zombienet/utils";
 import fs from "fs";
 import { Node } from "./types";
 
@@ -65,7 +66,7 @@ export async function generateKeystoreFiles(
   isStatemint: boolean = false,
 ): Promise<string[]> {
   const keystoreDir = `${path}/keystore`;
-  await fs.promises.mkdir(keystoreDir);
+  await makeDir(keystoreDir);
 
   const paths: string[] = [];
   const keysHash = {

--- a/javascript/packages/orchestrator/src/orchestrator.ts
+++ b/javascript/packages/orchestrator/src/orchestrator.ts
@@ -7,6 +7,7 @@ import {
   getLokiUrl,
   getSha256,
   loadTypeDef,
+  makeDir,
   series,
   sleep,
 } from "@zombienet/utils";
@@ -310,7 +311,7 @@ export async function start(
 
       const parachainFilesPromiseGenerator = async (parachain: Parachain) => {
         const parachainFilesPath = `${tmpDir.path}/${parachain.name}`;
-        await fs.promises.mkdir(parachainFilesPath);
+        await makeDir(parachainFilesPath);
         await generateParachainFiles(
           namespace,
           tmpDir.path,
@@ -465,9 +466,7 @@ export async function start(
         if (parachain && parachain.name) nodeFilesPath += `/${parachain.name}`;
         nodeFilesPath += `/${node.name}`;
 
-        if (!fs.existsSync(nodeFilesPath)) {
-          await fs.promises.mkdir(nodeFilesPath, { recursive: true });
-        }
+        await makeDir(nodeFilesPath, true);
 
         const isStatemint = parachain && parachain.chain?.includes("statemint");
         const keystoreFiles = await generateKeystoreFiles(

--- a/javascript/packages/orchestrator/src/orchestrator.ts
+++ b/javascript/packages/orchestrator/src/orchestrator.ts
@@ -127,17 +127,19 @@ export async function start(
       : await tmp.dir({ prefix: `${namespace}_` });
 
     // If custom path is provided then create it
-    if (opts.dir && !fs.existsSync(opts.dir)) {
-      fs.mkdirSync(opts.dir);
-    } else if (!opts.force) {
-      const response = await askQuestion(
-        `${decorators.yellow(
-          "Directory already exists; Everything will be overwritten;\nDo you want to continue? (y/N)",
-        )}`,
-      );
-      if (response.toLowerCase() !== "y") {
-        console.log("Exiting...");
-        process.exit(1);
+    if (opts.dir) {
+      if (!fs.existsSync(opts.dir)) {
+        fs.mkdirSync(opts.dir);
+      } else if (!opts.force) {
+        const response = await askQuestion(
+          `${decorators.yellow(
+            "Directory already exists; Everything will be overwritten;\nDo you want to continue? (y/N)",
+          )}`,
+        );
+        if (response.toLowerCase() !== "y") {
+          console.log("Exiting...");
+          process.exit(1);
+        }
       }
     }
 
@@ -850,7 +852,7 @@ export async function test(
 ) {
   let network: Network | undefined;
   try {
-    network = await start(credentials, networkConfig);
+    network = await start(credentials, networkConfig, { force: true });
     await cb(network);
   } catch (error) {
     console.error(error);

--- a/javascript/packages/orchestrator/src/providers/native/dynResourceDefinition.ts
+++ b/javascript/packages/orchestrator/src/providers/native/dynResourceDefinition.ts
@@ -1,4 +1,4 @@
-import { getRandomPort } from "@zombienet/utils";
+import { getRandomPort, makeDir } from "@zombienet/utils";
 import { genCmd, genCumulusCollatorCmd } from "../../cmdGenerator";
 import { getUniqueName } from "../../configGenerator";
 import {
@@ -11,8 +11,6 @@ import { Network } from "../../network";
 import { Node } from "../../types";
 import { getClient } from "../client";
 
-const fs = require("fs").promises;
-
 export async function genBootnodeDef(
   namespace: string,
   nodeSetup: Node,
@@ -23,10 +21,10 @@ export async function genBootnodeDef(
   const ports = await getPorts(rpcPort, wsPort, prometheusPort, p2pPort);
 
   const cfgPath = `${client.tmpDir}/${name}/cfg`;
-  await fs.mkdir(cfgPath, { recursive: true });
+  await makeDir(cfgPath, true);
 
   const dataPath = `${client.tmpDir}/${name}/data`;
-  await fs.mkdir(dataPath, { recursive: true });
+  await makeDir(dataPath, true);
 
   const command = await genCmd(nodeSetup, cfgPath, dataPath, false);
 
@@ -59,10 +57,10 @@ export async function genNodeDef(
   const { rpcPort, wsPort, prometheusPort, p2pPort } = nodeSetup;
   const ports = await getPorts(rpcPort, wsPort, prometheusPort, p2pPort);
   const cfgPath = `${client.tmpDir}/${name}/cfg`;
-  await fs.mkdir(cfgPath, { recursive: true });
+  await makeDir(cfgPath, true);
 
   const dataPath = `${client.tmpDir}/${name}/data`;
-  await fs.mkdir(dataPath, { recursive: true });
+  await makeDir(dataPath, true);
 
   let computedCommand;
   if (nodeSetup.zombieRole === "cumulus-collator") {

--- a/javascript/packages/orchestrator/src/providers/native/nativeClient.ts
+++ b/javascript/packages/orchestrator/src/providers/native/nativeClient.ts
@@ -1,6 +1,7 @@
 import {
   CreateLogTable,
   decorators,
+  makeDir,
   writeLocalJsonFile,
 } from "@zombienet/utils";
 import { spawn } from "child_process";
@@ -86,7 +87,7 @@ export class NativeClient extends Client {
     writeLocalJsonFile(this.tmpDir, "namespace", namespaceDef);
     // Native provider don't have the `namespace` isolation.
     // but we create the `remoteDir` to place files
-    await fs.promises.mkdir(this.remoteDir, { recursive: true });
+    await makeDir(this.remoteDir, true);
     return;
   }
   // Podman ONLY support `pods`
@@ -255,7 +256,7 @@ export class NativeClient extends Client {
     if (keystore) {
       // initialize keystore
       const keystoreRemoteDir = `${podDef.spec.dataPath}/chains/${chainSpecId}/keystore`;
-      await fs.promises.mkdir(keystoreRemoteDir, { recursive: true });
+      await makeDir(keystoreRemoteDir, true);
       // inject keys
       await fseCopy(keystore, keystoreRemoteDir);
     }

--- a/javascript/packages/orchestrator/src/providers/podman/dynResourceDefinition.ts
+++ b/javascript/packages/orchestrator/src/providers/podman/dynResourceDefinition.ts
@@ -1,4 +1,4 @@
-import { getRandomPort } from "@zombienet/utils";
+import { getRandomPort, makeDir } from "@zombienet/utils";
 import { resolve } from "path";
 import { genCmd, genCumulusCollatorCmd } from "../../cmdGenerator";
 import { getUniqueName } from "../../configGenerator";
@@ -53,8 +53,8 @@ export async function genPrometheusDef(namespace: string): Promise<any> {
   ];
   const cfgPath = `${client.tmpDir}/prometheus/etc`;
   const dataPath = `${client.tmpDir}/prometheus/data`;
-  await fs.mkdir(cfgPath, { recursive: true });
-  await fs.mkdir(dataPath, { recursive: true });
+  await makeDir(cfgPath, true);
+  await makeDir(dataPath, true);
 
   const devices = [
     { name: "prom-cfg", hostPath: { type: "Directory", path: cfgPath } },
@@ -134,7 +134,7 @@ export async function genGrafanaDef(
     },
   ];
   const datasourcesPath = `${client.tmpDir}/grafana/datasources`;
-  await fs.mkdir(datasourcesPath, { recursive: true });
+  await makeDir(datasourcesPath, true);
 
   const devices = [
     {
@@ -256,8 +256,8 @@ export async function genTempoDef(namespace: string): Promise<any> {
   ];
   const cfgPath = `${client.tmpDir}/tempo/etc`;
   const dataPath = `${client.tmpDir}/tempo/data`;
-  await fs.mkdir(cfgPath, { recursive: true });
-  await fs.mkdir(dataPath, { recursive: true });
+  await makeDir(cfgPath, true);
+  await makeDir(dataPath, true);
 
   const devices = [
     { name: "tempo-cfg", hostPath: { type: "Directory", path: cfgPath } },
@@ -374,9 +374,8 @@ async function make_volume_mounts(name: string): Promise<[any, any]> {
   const client = getClient();
   const cfgPath = `${client.tmpDir}/${name}/cfg`;
   const dataPath = `${client.tmpDir}/${name}/data`;
-  await fs.mkdir(cfgPath, { recursive: true });
-
-  await fs.mkdir(dataPath, { recursive: true });
+  await makeDir(cfgPath, true);
+  await makeDir(dataPath, true);
 
   const devices = [
     { name: "tmp-cfg", hostPath: { type: "Directory", path: cfgPath } },

--- a/javascript/packages/orchestrator/src/providers/podman/podmanClient.ts
+++ b/javascript/packages/orchestrator/src/providers/podman/podmanClient.ts
@@ -2,6 +2,7 @@ import {
   CreateLogTable,
   decorators,
   getHostIp,
+  makeDir,
   writeLocalJsonFile,
 } from "@zombienet/utils";
 import execa from "execa";
@@ -364,7 +365,7 @@ export class PodmanClient extends Client {
       debug("dataPath", dataPath);
       const keystoreRemoteDir = `${dataPath.hostPath.path}/chains/${chainSpecId}/keystore`;
       debug("keystoreRemoteDir", keystoreRemoteDir);
-      await fs.mkdir(keystoreRemoteDir, { recursive: true });
+      await makeDir(keystoreRemoteDir, true);
       // inject keys
       await fseCopy(keystore, keystoreRemoteDir);
       debug("keys injected");

--- a/javascript/packages/utils/src/fs.ts
+++ b/javascript/packages/utils/src/fs.ts
@@ -48,6 +48,12 @@ export function loadTypeDef(types: string | object): object {
   }
 }
 
+export async function makeDir(dir: string, recursive = false) {
+  if (!fs.existsSync(dir)) {
+    await fs.promises.mkdir(dir, { recursive });
+  }
+}
+
 export function getCredsFilePath(credsFile: string): string | undefined {
   if (fs.existsSync(credsFile)) return credsFile;
 


### PR DESCRIPTION
This PR addresses the need of having specific directory for running zombienet instead of a random/tmp one.

Can be reviewed by each commit.

What is added:
- New option of `--dir`, `-d` : A specific directory path can be passed to the CLI; Zombienet files/logs etc will be all under that CLI. If directory does not exist, it will be created (and all files under it); If directory exists, then user will be prompted for his wish to overwrite it or not;
-  New option of `--force`, `-f`:  This options overwrites any user prompts that may occur during the CLI run (e.g. the "Directory already exists - would you like to overwrite it")
- Add checks for all the directories - if they exist do not create them 
- Update documentation and README files

Fixes #264 