### PR TITLE
Add zombie script from monorepo root

### DIFF
--- a/javascript/package.json
+++ b/javascript/package.json
@@ -15,7 +15,8 @@
     "build": "npm run clean && npm run build --workspaces --if-present",
     "lint": "npm run lint --workspaces --if-present",
     "lint:write": "npm run lint:write --workspaces --if-present",
-    "package": "npm run -w packages/cli package"
+    "package": "npm run -w packages/cli package",
+    "zombie": "node ./packages/cli/dist/cli.js"
   },
   "engines": {
     "node": ">=16"


### PR DESCRIPTION
Makes life a bit easier:
- Instead of running:
```bash
~ node ./packages/cli/dist/cli.js spawn -p native -f ../examples/0004-small-network-cumulus.toml
```
now one can run this script with params:
```bash
~ npm run zombie -- spawn -p native -f ../examples/0004-small-network-cumulus.toml
```