### PR TITLE
Feat local ip config

### DIFF
--- a/docs/src/network-definition-spec.md
+++ b/docs/src/network-definition-spec.md
@@ -18,6 +18,7 @@ The network config can be provided both in `json` or `toml` format and each sect
 - `tracing_collator_service_namespace`: (String, default `tempo`) namespace where tempo is running, **only** available on `kubernetes`.
 - `tracing_collator_service_port`: (Number, default `3100`) port of the query instance of tempo, **only** available on `kubernetes`.
 - `node_spawn_timeout`: (Number, default per provider) timeout to spawn pod/process.
+- `local_ip`: (String, default "127.0.0.1") ip used for expose local services (rpc/metrics/monitors).
 
 ## `relaychain`
 

--- a/javascript/packages/orchestrator/src/orchestrator.ts
+++ b/javascript/packages/orchestrator/src/orchestrator.ts
@@ -533,7 +533,7 @@ export async function start(
           nodeIdentifier,
         );
 
-const listeningIp = networkSpec.settings.local_ip || LOCALHOST;
+        const listeningIp = networkSpec.settings.local_ip || LOCALHOST;
 
         networkNode = new NetworkNode(
           node.name,

--- a/javascript/packages/orchestrator/src/orchestrator.ts
+++ b/javascript/packages/orchestrator/src/orchestrator.ts
@@ -533,13 +533,15 @@ export async function start(
           nodeIdentifier,
         );
 
+const listeningIp = networkSpec.settings.local_ip || LOCALHOST;
+
         networkNode = new NetworkNode(
           node.name,
-          WS_URI_PATTERN.replace("{{IP}}", LOCALHOST).replace(
+          WS_URI_PATTERN.replace("{{IP}}", listeningIp).replace(
             "{{PORT}}",
             fwdPort.toString(),
           ),
-          METRICS_URI_PATTERN.replace("{{IP}}", LOCALHOST).replace(
+          METRICS_URI_PATTERN.replace("{{IP}}", listeningIp).replace(
             "{{PORT}}",
             nodePrometheusPort.toString(),
           ),

--- a/javascript/packages/orchestrator/src/providers/podman/podmanClient.ts
+++ b/javascript/packages/orchestrator/src/providers/podman/podmanClient.ts
@@ -12,6 +12,7 @@ import YAML from "yaml";
 import {
   DEFAULT_DATA_DIR,
   DEFAULT_REMOTE_DIR,
+  LOCALHOST,
   P2P_PORT,
   PROMETHEUS_PORT,
 } from "../../constants";
@@ -91,10 +92,12 @@ export class PodmanClient extends Client {
     const prometheusSpec = await genPrometheusDef(this.namespace);
     const promPort = prometheusSpec.spec.containers[0].ports[0].hostPort;
     await this.createResource(prometheusSpec, false, true);
+    const listeningIp = settings.local_ip || LOCALHOST;
+
     console.log(
       `\n\t Monitor: ${decorators.green(
         prometheusSpec.metadata.name,
-      )} - url: http://127.0.0.1:${promPort}`,
+      )} - url: http://${listeningIp}:${promPort}`,
     );
 
     const tempoSpec = await genTempoDef(this.namespace);
@@ -104,7 +107,7 @@ export class PodmanClient extends Client {
     console.log(
       `\n\t Monitor: ${decorators.green(
         tempoSpec.metadata.name,
-      )} - url: http://127.0.0.1:${tempoPort}`,
+      )} - url: http://${listeningIp}:${tempoPort}`,
     );
 
     const prometheusIp = await this.getNodeIP("prometheus");
@@ -119,7 +122,7 @@ export class PodmanClient extends Client {
     console.log(
       `\n\t Monitor: ${decorators.green(
         grafanaSpec.metadata.name,
-      )} - url: http://127.0.0.1:${grafanaPort}`,
+      )} - url: http://${listeningIp}:${grafanaPort}`,
     );
   }
 

--- a/javascript/packages/orchestrator/src/types.ts
+++ b/javascript/packages/orchestrator/src/types.ts
@@ -36,6 +36,7 @@ export interface Settings {
   polkadot_introspector?: boolean;
   backchannel?: boolean; // only used in k8s at the moment, spawn a backchannel instance
   image_pull_policy?: "IfNotPresent" | "Never" | "Always";
+  local_ip?: string;
 }
 
 export interface RelayChainConfig {

--- a/javascript/packages/orchestrator/src/types.ts
+++ b/javascript/packages/orchestrator/src/types.ts
@@ -36,7 +36,7 @@ export interface Settings {
   polkadot_introspector?: boolean;
   backchannel?: boolean; // only used in k8s at the moment, spawn a backchannel instance
   image_pull_policy?: "IfNotPresent" | "Never" | "Always";
-  local_ip?: string;
+  local_ip?: string; // ip used for expose local services (rpc/metrics/monitors)
 }
 
 export interface RelayChainConfig {


### PR DESCRIPTION
Allow to customize the `ip` used for links (rpc/metrics/monitor).

This will only works locally and **not** in the `CI`.

Thanks!

cc: @drahnr 