### PR TITLE
Check if tracing is enabled

### DIFF
--- a/javascript/packages/orchestrator/src/orchestrator.ts
+++ b/javascript/packages/orchestrator/src/orchestrator.ts
@@ -407,7 +407,10 @@ export async function start(
 
     const monitorIsAvailable = await client.isPodMonitorAvailable();
     let jaegerUrl: string;
-    if (client.providerName === "podman" && networkSpec.settings.enable_tracing) {
+    if (
+      client.providerName === "podman" &&
+      networkSpec.settings.enable_tracing
+    ) {
       const jaegerIp = await client.getNodeIP("tempo");
       jaegerUrl = `${jaegerIp}:6831`;
     } else if (

--- a/javascript/packages/orchestrator/src/orchestrator.ts
+++ b/javascript/packages/orchestrator/src/orchestrator.ts
@@ -407,7 +407,7 @@ export async function start(
 
     const monitorIsAvailable = await client.isPodMonitorAvailable();
     let jaegerUrl: string;
-    if (client.providerName === "podman") {
+    if (client.providerName === "podman" && networkSpec.settings.enable_tracing) {
       const jaegerIp = await client.getNodeIP("tempo");
       jaegerUrl = `${jaegerIp}:6831`;
     } else if (


### PR DESCRIPTION
For `podman` we assume that the tracing (jaeger) is enabled in the node and that wrong, for example `substrate` don't use it. So, now you can set `enable_tracing` to false and will work with `substrate`.

cc @michalkucharczyk 