### PR TITLE
add logic to use command_with_args for cumulus collators

### DIFF
--- a/javascript/packages/orchestrator/src/cmdGenerator.ts
+++ b/javascript/packages/orchestrator/src/cmdGenerator.ts
@@ -41,7 +41,8 @@ export async function genCumulusCollatorCmd(
   dataPath: string = "/data",
   useWrapper = true,
 ): Promise<string[]> {
-  const { name, chain, parachainId, key, validator, commandWithArgs } = nodeSetup;
+  const { name, chain, parachainId, key, validator, commandWithArgs } =
+    nodeSetup;
 
   // command with args
   if (commandWithArgs) {

--- a/javascript/packages/orchestrator/src/cmdGenerator.ts
+++ b/javascript/packages/orchestrator/src/cmdGenerator.ts
@@ -41,7 +41,13 @@ export async function genCumulusCollatorCmd(
   dataPath: string = "/data",
   useWrapper = true,
 ): Promise<string[]> {
-  const { name, chain, parachainId, key, validator } = nodeSetup;
+  const { name, chain, parachainId, key, validator, commandWithArgs } = nodeSetup;
+
+  // command with args
+  if (commandWithArgs) {
+    return parseCmdWithArguments(commandWithArgs);
+  }
+
   const parachainAddedArgs: any = {
     "--name": true,
     "--collator": true,


### PR DESCRIPTION
Fixes #593 

- Add logic to parse `commandWithArgs` if is set for the collator (cumulus).