### PR TITLE
add volumes for `podman`/`k8s`

### DIFF
--- a/javascript/packages/orchestrator/src/providers/k8s/dynResourceDefinition.ts
+++ b/javascript/packages/orchestrator/src/providers/k8s/dynResourceDefinition.ts
@@ -132,7 +132,11 @@ function make_volume_mounts(): [any, any] {
     { name: "tmp-relay-data", mountPath: "/relay-data", readOnly: false },
   ];
 
-  const devices = [{ name: "tmp-cfg" }, { name: "tmp-data" }, { name: "tmp-relay-data" }];
+  const devices = [
+    { name: "tmp-cfg" },
+    { name: "tmp-data" },
+    { name: "tmp-relay-data" },
+  ];
 
   return [volume_mounts, devices];
 }

--- a/javascript/packages/orchestrator/src/providers/k8s/dynResourceDefinition.ts
+++ b/javascript/packages/orchestrator/src/providers/k8s/dynResourceDefinition.ts
@@ -129,9 +129,10 @@ function make_volume_mounts(): [any, any] {
   const volume_mounts = [
     { name: "tmp-cfg", mountPath: "/cfg", readOnly: false },
     { name: "tmp-data", mountPath: "/data", readOnly: false },
+    { name: "tmp-relay-data", mountPath: "/relay-data", readOnly: false },
   ];
 
-  const devices = [{ name: "tmp-cfg" }, { name: "tmp-data" }];
+  const devices = [{ name: "tmp-cfg" }, { name: "tmp-data" }, { name: "tmp-relay-data" }];
 
   return [volume_mounts, devices];
 }

--- a/javascript/packages/orchestrator/src/providers/podman/dynResourceDefinition.ts
+++ b/javascript/packages/orchestrator/src/providers/podman/dynResourceDefinition.ts
@@ -383,7 +383,10 @@ async function make_volume_mounts(name: string): Promise<[any, any]> {
   const devices = [
     { name: "tmp-cfg", hostPath: { type: "Directory", path: cfgPath } },
     { name: "tmp-data", hostPath: { type: "Directory", path: dataPath } },
-    { name: "tmp-relay-data", hostPath: { type: "Directory", path: relayDataPath } },
+    {
+      name: "tmp-relay-data",
+      hostPath: { type: "Directory", path: relayDataPath },
+    },
   ];
 
   return [volume_mounts, devices];

--- a/javascript/packages/orchestrator/src/providers/podman/dynResourceDefinition.ts
+++ b/javascript/packages/orchestrator/src/providers/podman/dynResourceDefinition.ts
@@ -369,17 +369,21 @@ async function make_volume_mounts(name: string): Promise<[any, any]> {
   const volume_mounts = [
     { name: "tmp-cfg", mountPath: "/cfg:U", readOnly: false },
     { name: "tmp-data", mountPath: "/data:U", readOnly: false },
+    { name: "tmp-relay-data", mountPath: "/relay-data:U", readOnly: false },
   ];
 
   const client = getClient();
   const cfgPath = `${client.tmpDir}/${name}/cfg`;
   const dataPath = `${client.tmpDir}/${name}/data`;
+  const relayDataPath = `${client.tmpDir}/${name}/relay-data`;
   await makeDir(cfgPath, true);
   await makeDir(dataPath, true);
+  await makeDir(relayDataPath, true);
 
   const devices = [
     { name: "tmp-cfg", hostPath: { type: "Directory", path: cfgPath } },
     { name: "tmp-data", hostPath: { type: "Directory", path: dataPath } },
+    { name: "tmp-relay-data", hostPath: { type: "Directory", path: relayDataPath } },
   ];
 
   return [volume_mounts, devices];


### PR DESCRIPTION
This is a follow up needed by https://github.com/paritytech/zombienet/pull/491, since that `pr` have the fix for `native` and the cmd logic.

cc @MucTepDayH16 