### PR TITLE
Edit overwrite message when using same directory

### DIFF
--- a/javascript/packages/orchestrator/src/orchestrator.ts
+++ b/javascript/packages/orchestrator/src/orchestrator.ts
@@ -133,7 +133,7 @@ export async function start(
       } else if (!opts.force) {
         const response = await askQuestion(
           `${decorators.yellow(
-            "Directory already exists; Everything will be overwritten;\nDo you want to continue? (y/N)",
+            "Directory already exists; \nDo you want to continue? (y/N)",
           )}`,
         );
         if (response.toLowerCase() !== "y") {


### PR DESCRIPTION
After @hbulgarini 's feedback this alters the message that appears, when same directory is used.