### PR TITLE
use 'useWrapper' in parseCmdWithArguments

### DIFF
--- a/javascript/packages/orchestrator/src/cmdGenerator.ts
+++ b/javascript/packages/orchestrator/src/cmdGenerator.ts
@@ -47,7 +47,7 @@ export async function genCumulusCollatorCmd(
 
   // command with args
   if (commandWithArgs) {
-    return parseCmdWithArguments(commandWithArgs);
+    return parseCmdWithArguments(commandWithArgs, useWrapper);
   }
 
   const parachainAddedArgs: any = {


### PR DESCRIPTION
Fix #406 