### PR TITLE
Added assertion for matching lines count

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -285,7 +285,7 @@ dependencies = [
 
 [[package]]
 name = "dsl-parser-wrapper"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "parser",
  "serde_json",

--- a/crates/parser-wrapper/Cargo.toml
+++ b/crates/parser-wrapper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dsl-parser-wrapper"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 description = "Zombienet DSL parser: produces a test definition, in json format, that can be used with the ZombieNet's test-runnner."
 license = "GPL-3.0-or-later"

--- a/crates/parser/src/ast.rs
+++ b/crates/parser/src/ast.rs
@@ -80,6 +80,15 @@ pub enum AssertionKind {
         #[serde(with = "optional_timeout")]
         timeout: Option<Duration>,
     },
+    CountLogMatch {
+        node_name: NodeName,
+        match_type: String,
+        pattern: String,
+        op: Operator,
+        target_value: u64,
+        #[serde(with = "optional_timeout")]
+        timeout: Option<Duration>,
+    },
     Trace {
         node_name: NodeName,
         span_id: String,

--- a/crates/parser/src/lib.rs
+++ b/crates/parser/src/lib.rs
@@ -451,7 +451,8 @@ pub fn parse(unparsed_file: &str) -> Result<ast::TestDefinition, errors::ParserE
                 assertions.push(assertion);
             }
             Rule::count_log_match => {
-                let (name, match_type, pattern, comparison, timeout) = parse_lines_count_match_pattern_rule(record)?;
+                let (name, match_type, pattern, comparison, timeout) =
+                    parse_lines_count_match_pattern_rule(record)?;
 
                 let assertion = Assertion {
                     parsed: AssertionKind::CountLogMatch {

--- a/crates/parser/src/tests.rs
+++ b/crates/parser/src/tests.rs
@@ -309,7 +309,8 @@ fn log_match_glob_parse_ok() {
 
 #[test]
 fn count_log_match_equal_parse_ok() {
-    let line: &str = r#"alice: count of log lines containing "Imported #12" is 0 within 20 seconds"#;
+    let line: &str =
+        r#"alice: count of log lines containing "Imported #12" is 0 within 20 seconds"#;
     let data = r#"{
         "description": null,
         "network": "./a.toml",
@@ -339,7 +340,8 @@ fn count_log_match_equal_parse_ok() {
 
 #[test]
 fn count_log_match_is_at_least_parse_ok() {
-    let line: &str = r#"alice: count of log lines containing "Imported #12" is at least 12 within 20 seconds"#;
+    let line: &str =
+        r#"alice: count of log lines containing "Imported #12" is at least 12 within 20 seconds"#;
     let data = r#"{
         "description": null,
         "network": "./a.toml",
@@ -369,7 +371,8 @@ fn count_log_match_is_at_least_parse_ok() {
 
 #[test]
 fn count_log_match_glob_equal_parse_ok() {
-    let line: &str = r#"alice: count of log lines containing glob "Imported #12" is 10 within 20 seconds"#;
+    let line: &str =
+        r#"alice: count of log lines containing glob "Imported #12" is 10 within 20 seconds"#;
     let data = r#"{
         "description": null,
         "network": "./a.toml",
@@ -399,7 +402,8 @@ fn count_log_match_glob_equal_parse_ok() {
 
 #[test]
 fn count_log_match_glob_is_at_least_parse_ok() {
-    let line: &str = r#"alice: count of log lines matching glob "*rted #1*" is at least 5 within 10 seconds"#;
+    let line: &str =
+        r#"alice: count of log lines matching glob "*rted #1*" is at least 5 within 10 seconds"#;
     let data = r#"{
         "description": null,
         "network": "./a.toml",
@@ -426,7 +430,6 @@ fn count_log_match_glob_is_at_least_parse_ok() {
     let result = parse(&[NETWORK, CREDS, line].join("\n")).unwrap();
     assert_eq!(result, t);
 }
-
 
 #[test]
 fn trace_parse_ok() {

--- a/crates/parser/src/tests.rs
+++ b/crates/parser/src/tests.rs
@@ -308,6 +308,127 @@ fn log_match_glob_parse_ok() {
 }
 
 #[test]
+fn count_log_match_equal_parse_ok() {
+    let line: &str = r#"alice: count of log lines containing "Imported #12" is 0 within 20 seconds"#;
+    let data = r#"{
+        "description": null,
+        "network": "./a.toml",
+        "creds": "config",
+        "assertions": [
+            {
+                "original_line": "alice: count of log lines containing \"Imported #12\" is 0 within 20 seconds",
+                "parsed": {
+                  "fn": "CountLogMatch",
+                  "args": {
+                    "node_name": "alice",
+                    "match_type": "regex",
+                    "pattern": "Imported #12",
+                    "op": "Equal",
+                    "target_value": 0,
+                    "timeout": 20
+                  }
+                }
+            }
+        ]
+    }"#;
+    let t: TestDefinition = serde_json::from_str(data).unwrap();
+
+    let result = parse(&[NETWORK, CREDS, line].join("\n")).unwrap();
+    assert_eq!(result, t);
+}
+
+#[test]
+fn count_log_match_is_at_least_parse_ok() {
+    let line: &str = r#"alice: count of log lines containing "Imported #12" is at least 12 within 20 seconds"#;
+    let data = r#"{
+        "description": null,
+        "network": "./a.toml",
+        "creds": "config",
+        "assertions": [
+            {
+                "original_line": "alice: count of log lines containing \"Imported #12\" is at least 12 within 20 seconds",
+                "parsed": {
+                  "fn": "CountLogMatch",
+                  "args": {
+                    "node_name": "alice",
+                    "match_type": "regex",
+                    "pattern": "Imported #12",
+                    "op": "IsAtLeast",
+                    "target_value": 12,
+                    "timeout": 20
+                  }
+                }
+            }
+        ]
+    }"#;
+    let t: TestDefinition = serde_json::from_str(data).unwrap();
+
+    let result = parse(&[NETWORK, CREDS, line].join("\n")).unwrap();
+    assert_eq!(result, t);
+}
+
+#[test]
+fn count_log_match_glob_equal_parse_ok() {
+    let line: &str = r#"alice: count of log lines containing glob "Imported #12" is 10 within 20 seconds"#;
+    let data = r#"{
+        "description": null,
+        "network": "./a.toml",
+        "creds": "config",
+        "assertions": [
+            {
+                "original_line": "alice: count of log lines containing glob \"Imported #12\" is 10 within 20 seconds",
+                "parsed": {
+                  "fn": "CountLogMatch",
+                  "args": {
+                    "node_name": "alice",
+                    "match_type": "glob",
+                    "pattern": "Imported #12",
+                    "op": "Equal",
+                    "target_value": 10,
+                    "timeout": 20
+                  }
+                }
+            }
+        ]
+    }"#;
+    let t: TestDefinition = serde_json::from_str(data).unwrap();
+
+    let result = parse(&[NETWORK, CREDS, line].join("\n")).unwrap();
+    assert_eq!(result, t);
+}
+
+#[test]
+fn count_log_match_glob_is_at_least_parse_ok() {
+    let line: &str = r#"alice: count of log lines matching glob "*rted #1*" is at least 5 within 10 seconds"#;
+    let data = r#"{
+        "description": null,
+        "network": "./a.toml",
+        "creds": "config",
+        "assertions": [
+            {
+                "original_line": "alice: count of log lines matching glob \"*rted #1*\" is at least 5 within 10 seconds",
+                "parsed": {
+                  "fn": "CountLogMatch",
+                  "args": {
+                    "node_name": "alice",
+                    "match_type": "glob",
+                    "pattern": "*rted #1*",
+                    "op": "IsAtLeast",
+                    "target_value": 5,
+                    "timeout": 10
+                  }
+                }
+            }
+        ]
+    }"#;
+    let t: TestDefinition = serde_json::from_str(data).unwrap();
+
+    let result = parse(&[NETWORK, CREDS, line].join("\n")).unwrap();
+    assert_eq!(result, t);
+}
+
+
+#[test]
 fn trace_parse_ok() {
     let line: &str = r#"alice: trace with traceID 94c1501a78a0d83c498cc92deec264d9 contains ["answer-chunk-request", "answer-chunk-request"]"#;
     let data = r#"{

--- a/crates/parser/src/zombienet.pest
+++ b/crates/parser/src/zombienet.pest
@@ -64,6 +64,7 @@ para_runtime_dummy_upgrade = { node_name ~ parachain ~ "perform dummy upgrade" ~
 histogram = { node_name ~ "reports histogram" ~ metric_name ~ "has" ~ (comparison | int+) ~ "samples in buckets" ~ square_brackets_strings ~ within? }
 report = { node_name ~ "reports" ~ metric_name ~ comparison ~ within? }
 log_match = { node_name ~ "log line" ~ ("contains"|"matches") ~ match_type? ~ double_quoted_string ~ within? }
+count_log_match = { node_name ~ "count of log lines" ~ ("containing"|"matching") ~ match_type? ~ double_quoted_string ~ "is" ~ (comparison | int+) ~ within? }
 trace = { node_name ~ "trace with traceID" ~ span_id ~ "contains" ~ square_brackets_strings ~ within? }
 system_event = { node_name ~ "system event" ~ ("contains"|"matches") ~ match_type? ~ double_quoted_string ~ within? }
 custom_js = { node_name ~ "js-script" ~ file_path ~ ("with" ~ double_quoted_string)? ~ ( "return" ~ comparison )? ~ within? }
@@ -93,6 +94,7 @@ file = { SOI ~ (
     histogram |
     report |
     log_match |
+    count_log_match |
     trace |
     system_event |
     custom_js |

--- a/docs/src/cli/test-dsl-definition-spec.md
+++ b/docs/src/cli/test-dsl-definition-spec.md
@@ -55,6 +55,11 @@ The first lines are used to define the **header fields**:
   - `node-name`: log line (contains|matches) ( regex|glob) "pattern" [within x seconds]
     - alice: log line matches glob "_rted #1_" within 10 seconds
 
+- Logs assertions: Get logs from nodes and assert on the number of lines matching pattern (support `regex` and `glob`).
+
+  - `node-name`: count of log lines (containing|matcheing) ( regex|glob) "pattern" [within x seconds]
+    - alice: count of log lines matching glob "_rted #1_" within 10 seconds
+
 - System events assertion: Find a `system event` from subscription by matching a `pattern`. _NOTE_ the subscription is made when we start this particular test, so we **can not** match on event in the past.
 
   - `node-name`: system event (contains|matches)( regex| glob) "pattern" [within x seconds]

--- a/docs/src/guide.md
+++ b/docs/src/guide.md
@@ -75,6 +75,7 @@ alice: reports histogram polkadot_pvf_execution_time has at least 2 samples in b
 # logs
 bob: log line matches glob "*rted #1*" within 10 seconds
 bob: log line matches "Imported #[0-9]+" within 10 seconds
+bob: count of log lines maching "Error" is 0 within 10 seconds
 
 # system events
 bob: system event contains "A candidate was included" within 20 seconds

--- a/javascript/packages/cli/package.json
+++ b/javascript/packages/cli/package.json
@@ -49,7 +49,7 @@
     "url": "https://github.com/paritytech/zombienet/issues"
   },
   "dependencies": {
-    "@zombienet/dsl-parser-wrapper": "^0.1.6",
+    "@zombienet/dsl-parser-wrapper": "^0.1.7",
     "@zombienet/orchestrator": "^0.0.11",
     "@zombienet/utils": "^0.0.6",
     "axios": "^0.27.2",

--- a/javascript/packages/orchestrator/src/networkNode.ts
+++ b/javascript/packages/orchestrator/src/networkNode.ts
@@ -378,35 +378,36 @@ export class NetworkNode implements NetworkNodeInterface {
     timeout: number = DEFAULT_INDIVIDUAL_TEST_TIMEOUT,
   ): Promise<number> {
     try {
-      let total_count  = 0;
+      let total_count = 0;
       const re = isGlob ? minimatch.makeRe(pattern) : new RegExp(pattern, "ig");
       if (!re) throw new Error(`Invalid glob pattern: ${pattern} `);
       const client = getClient();
-      const getValue = async () : Promise<number> => {
-	await new Promise((resolve) => setTimeout(resolve, timeout*1000));
-	let logs = await client.getNodeLogs(this.name, undefined, true);
+      const getValue = async (): Promise<number> => {
+        await new Promise((resolve) => setTimeout(resolve, timeout * 1000));
+        let logs = await client.getNodeLogs(this.name, undefined, true);
 
-	for (let line of logs.split("\n")) {
-	  if (client.providerName !== "native") {
-	    // remove the extra timestamp
-	    line = line.split(" ").slice(1).join(" ");
-	  }
-	  if (re.test(line)) {
-	    total_count += 1;
-	  }
-	}
-	return total_count;
+        for (let line of logs.split("\n")) {
+          if (client.providerName !== "native") {
+            // remove the extra timestamp
+            line = line.split(" ").slice(1).join(" ");
+          }
+          if (re.test(line)) {
+            total_count += 1;
+          }
+        }
+        return total_count;
       };
 
       const resp = await Promise.race([
         getValue(),
-        new Promise((resolve) =>
-          setTimeout(() => {
-            const err = new Error(
-              `Timeout(${timeout}), "getting log pattern ${pattern} within ${timeout} secs".`,
-            );
-            return resolve(err);
-          }, (timeout + 2) * 1000), //extra 2s for processing log
+        new Promise(
+          (resolve) =>
+            setTimeout(() => {
+              const err = new Error(
+                `Timeout(${timeout}), "getting log pattern ${pattern} within ${timeout} secs".`,
+              );
+              return resolve(err);
+            }, (timeout + 2) * 1000), //extra 2s for processing log
         ),
       ]);
       if (resp instanceof Error) throw resp;

--- a/javascript/packages/orchestrator/src/networkNode.ts
+++ b/javascript/packages/orchestrator/src/networkNode.ts
@@ -372,6 +372,56 @@ export class NetworkNode implements NetworkNodeInterface {
     }
   }
 
+  async countPatternLines(
+    pattern: string,
+    isGlob: boolean,
+    timeout: number = DEFAULT_INDIVIDUAL_TEST_TIMEOUT,
+  ): Promise<number> {
+    try {
+      let total_count  = 0;
+      const re = isGlob ? minimatch.makeRe(pattern) : new RegExp(pattern, "ig");
+      if (!re) throw new Error(`Invalid glob pattern: ${pattern} `);
+      const client = getClient();
+      const getValue = async () : Promise<number> => {
+	await new Promise((resolve) => setTimeout(resolve, timeout*1000));
+	let logs = await client.getNodeLogs(this.name, 2, true);
+
+	for (let line of logs.split("\n")) {
+	  if (client.providerName !== "native") {
+	    // remove the extra timestamp
+	    line = line.split(" ").slice(1).join(" ");
+	  }
+	  if (re.test(line)) {
+	    total_count += 1;
+	  }
+	}
+	return total_count;
+      };
+
+      const resp = await Promise.race([
+        getValue(),
+        new Promise((resolve) =>
+          setTimeout(() => {
+            const err = new Error(
+              `Timeout(${timeout}), "getting log pattern ${pattern} within ${timeout} secs".`,
+            );
+            return resolve(err);
+          }, (timeout + 2) * 1000), //extra 2s for processing log
+        ),
+      ]);
+      if (resp instanceof Error) throw resp;
+
+      return total_count;
+    } catch (err: any) {
+      console.log(
+        `\n\t ${decorators.red("Error: ")} \n\t\t ${decorators.red(
+          err.message,
+        )}\n`,
+      );
+      return 0;
+    }
+  }
+
   async findPattern(
     pattern: string,
     isGlob: boolean,

--- a/javascript/packages/orchestrator/src/networkNode.ts
+++ b/javascript/packages/orchestrator/src/networkNode.ts
@@ -384,7 +384,7 @@ export class NetworkNode implements NetworkNodeInterface {
       const client = getClient();
       const getValue = async () : Promise<number> => {
 	await new Promise((resolve) => setTimeout(resolve, timeout*1000));
-	let logs = await client.getNodeLogs(this.name, 2, true);
+	let logs = await client.getNodeLogs(this.name, undefined, true);
 
 	for (let line of logs.split("\n")) {
 	  if (client.providerName !== "native") {

--- a/javascript/packages/orchestrator/src/test-runner/assertions.ts
+++ b/javascript/packages/orchestrator/src/test-runner/assertions.ts
@@ -135,6 +135,22 @@ const LogMatch = ({ node_name, pattern, match_type, timeout }: FnArgs) => {
   };
 };
 
+const CountLogMatch = ({ node_name, pattern, match_type, op, target_value, timeout }: FnArgs) => {
+  const comparatorFn = comparators[op!];
+  const isGlob = (match_type && match_type.trim() === "glob") || false;
+
+  return async (network: Network) => {
+    const nodes = network.getNodes(node_name!);
+    const results = await Promise.all(
+      nodes.map((node: any) => node.countPatternLines(pattern!, isGlob, timeout)),
+    );
+
+    for (const value of results) {
+      comparatorFn(value as number, target_value as number);
+    }
+  };
+};
+
 const SystemEvent = ({ node_name, pattern, match_type, timeout }: FnArgs) => {
   const isGlob = (match_type && match_type.trim() === "glob") || false;
 
@@ -412,6 +428,7 @@ export default {
   Histogram,
   Trace,
   LogMatch,
+  CountLogMatch,
   SystemEvent,
   CustomJs,
   CustomSh,

--- a/javascript/packages/orchestrator/src/test-runner/assertions.ts
+++ b/javascript/packages/orchestrator/src/test-runner/assertions.ts
@@ -135,14 +135,23 @@ const LogMatch = ({ node_name, pattern, match_type, timeout }: FnArgs) => {
   };
 };
 
-const CountLogMatch = ({ node_name, pattern, match_type, op, target_value, timeout }: FnArgs) => {
+const CountLogMatch = ({
+  node_name,
+  pattern,
+  match_type,
+  op,
+  target_value,
+  timeout,
+}: FnArgs) => {
   const comparatorFn = comparators[op!];
   const isGlob = (match_type && match_type.trim() === "glob") || false;
 
   return async (network: Network) => {
     const nodes = network.getNodes(node_name!);
     const results = await Promise.all(
-      nodes.map((node: any) => node.countPatternLines(pattern!, isGlob, timeout)),
+      nodes.map((node: any) =>
+        node.countPatternLines(pattern!, isGlob, timeout),
+      ),
     );
 
     for (const value of results) {

--- a/tests/0006-logs.zndsl
+++ b/tests/0006-logs.zndsl
@@ -9,3 +9,6 @@ alice: reports block height is at least 10 within 200 seconds
 alice: log line contains "Imported #12" within 20 seconds
 alice: log line matches glob "*rted #1*" within 10 seconds
 alice: log line matches "Imported #[0-9]+" within 10 seconds
+alice: count of log lines containing "imported" is at least 10 within 10 seconds
+alice: count of log lines containing "error" is 0 within 10 seconds
+bob: count of log lines containing "error" is 0 within 10 seconds


### PR DESCRIPTION
This allows to add assertion for number of lines matchin given pattern, e.g:
```
alice: count of log lines containing "error" is 0 within 30s
```

The syntax is:
```
node_name: count of log lines (containing|matching) "pattern" is <comparator> <number> [within]
```

Currently the implementation waits `timeout` amount of time, and then captures and searches the log.
Assertions are not executed in parallel.

Fixes: #598