### PR TITLE
remove scope to exec in `podman`

### DIFF
--- a/javascript/packages/orchestrator/src/providers/podman/podmanClient.ts
+++ b/javascript/packages/orchestrator/src/providers/podman/podmanClient.ts
@@ -318,18 +318,16 @@ export class PodmanClient extends Client {
 
       // set as executable
       const baseArgs = ["exec", identifier];
-      await this.runCommand(
-        [...baseArgs, "/bin/chmod", "+x", scriptPathInPod],
-        undefined,
-        true,
-      );
+      await this.runCommand([...baseArgs, "/bin/chmod", "+x", scriptPathInPod]);
 
       // exec
-      const result = await this.runCommand(
-        [...baseArgs, "bash", "-c", scriptPathInPod, ...args],
-        undefined,
-        true,
-      );
+      const result = await this.runCommand([
+        ...baseArgs,
+        "bash",
+        "-c",
+        scriptPathInPod,
+        ...args,
+      ]);
 
       return {
         exitCode: result.exitCode,


### PR DESCRIPTION
Fix run scripts (bash) in podman.

Fix #597 

cc: @michalkucharczyk 