### PR TITLE
fix use wrapper for native (not cumulus)

### DIFF
--- a/javascript/packages/orchestrator/src/cmdGenerator.ts
+++ b/javascript/packages/orchestrator/src/cmdGenerator.ts
@@ -247,7 +247,7 @@ export async function genCmd(
 
   // command with args
   if (commandWithArgs) {
-    return parseCmdWithArguments(commandWithArgs);
+    return parseCmdWithArguments(commandWithArgs, useWrapper);
   }
 
   if (!command) command = DEFAULT_COMMAND;


### PR DESCRIPTION
fixes #406

Fix: pass `useWrapper` to create cmd with args.
