### PR TITLE
refactor `wait_node_ready` for native provider

### DIFF
--- a/javascript/packages/orchestrator/src/providers/native/nativeClient.ts
+++ b/javascript/packages/orchestrator/src/providers/native/nativeClient.ts
@@ -348,6 +348,8 @@ export class NativeClient extends Client {
   async wait_node_ready(nodeName: string): Promise<void> {
     // check if the process is alive after 1 seconds
     await sleep(1000);
+    const procNodeName = this.processMap[nodeName];
+    const { pid, logs } = procNodeName;
     const result = await this.runCommand([
       "-c",
       `ps ${this.processMap[nodeName].pid}`,

--- a/javascript/packages/orchestrator/src/providers/native/nativeClient.ts
+++ b/javascript/packages/orchestrator/src/providers/native/nativeClient.ts
@@ -388,7 +388,7 @@ export class NativeClient extends Client {
       return;
 
     throw new Error(
-      `Log lines of process: ${this.processMap[nodeName].pid} ( node: ${nodeName} ) doesn't grow, please check logs at ${this.processMap[nodeName].logs}`,
+      `Log lines of process: ${pid} ( node: ${nodeName} ) doesn't grow, please check logs at ${logs}`,
     );
   }
 

--- a/javascript/packages/orchestrator/src/providers/native/nativeClient.ts
+++ b/javascript/packages/orchestrator/src/providers/native/nativeClient.ts
@@ -356,7 +356,7 @@ export class NativeClient extends Client {
     ]);
     if (result.exitCode > 0)
       throw new Error(
-        `Process: ${this.processMap[nodeName].pid}, for node: ${nodeName} dies`,
+        `Process: ${pid}, for node: ${nodeName} dies`,
       );
 
     // check log lines grow between 2/6/12 secs

--- a/javascript/packages/orchestrator/src/providers/native/nativeClient.ts
+++ b/javascript/packages/orchestrator/src/providers/native/nativeClient.ts
@@ -1,9 +1,9 @@
 import {
-  sleep,
   CreateLogTable,
   decorators,
   downloadFile,
   makeDir,
+  sleep,
   writeLocalJsonFile,
 } from "@zombienet/utils";
 import { spawn } from "child_process";
@@ -358,17 +358,32 @@ export class NativeClient extends Client {
       );
 
     // check log lines grow between 2/6/12 secs
-    const lines_1 = await this.runCommand(["-c", `wc -l ${this.processMap[nodeName].logs}`]);
+    const lines_1 = await this.runCommand([
+      "-c",
+      `wc -l ${this.processMap[nodeName].logs}`,
+    ]);
     await sleep(2000);
-    const lines_2 = await this.runCommand(["-c", `wc -l ${this.processMap[nodeName].logs}`]);
-    if(parseInt(lines_2.stdout.trim()) > parseInt(lines_1.stdout.trim())) return;
+    const lines_2 = await this.runCommand([
+      "-c",
+      `wc -l ${this.processMap[nodeName].logs}`,
+    ]);
+    if (parseInt(lines_2.stdout.trim()) > parseInt(lines_1.stdout.trim()))
+      return;
     await sleep(6000);
-    const lines_3 = await this.runCommand(["-c", `wc -l ${this.processMap[nodeName].logs}`]);
-    if(parseInt(lines_3.stdout.trim()) > parseInt(lines_1.stdout.trim())) return;
+    const lines_3 = await this.runCommand([
+      "-c",
+      `wc -l ${this.processMap[nodeName].logs}`,
+    ]);
+    if (parseInt(lines_3.stdout.trim()) > parseInt(lines_1.stdout.trim()))
+      return;
 
     await sleep(12000);
-    const lines_4 = await this.runCommand(["-c", `wc -l ${this.processMap[nodeName].logs}`]);
-    if(parseInt(lines_4.stdout.trim()) > parseInt(lines_1.stdout.trim())) return;
+    const lines_4 = await this.runCommand([
+      "-c",
+      `wc -l ${this.processMap[nodeName].logs}`,
+    ]);
+    if (parseInt(lines_4.stdout.trim()) > parseInt(lines_1.stdout.trim()))
+      return;
 
     throw new Error(
       `Log lines of process: ${this.processMap[nodeName].pid} ( node: ${nodeName} ) doesn't grow, please check logs at ${this.processMap[nodeName].logs}`,

--- a/javascript/packages/orchestrator/src/providers/native/nativeClient.ts
+++ b/javascript/packages/orchestrator/src/providers/native/nativeClient.ts
@@ -350,40 +350,23 @@ export class NativeClient extends Client {
     await sleep(1000);
     const procNodeName = this.processMap[nodeName];
     const { pid, logs } = procNodeName;
-    const result = await this.runCommand([
-      "-c",
-      `ps ${pid}`,
-    ]);
+    const result = await this.runCommand(["-c", `ps ${pid}`]);
     if (result.exitCode > 0)
-      throw new Error(
-        `Process: ${pid}, for node: ${nodeName} dies`,
-      );
+      throw new Error(`Process: ${pid}, for node: ${nodeName} dies`);
 
     // check log lines grow between 2/6/12 secs
-    const lines_1 = await this.runCommand([
-      "-c",
-      `wc -l ${logs}`,
-    ]);
+    const lines_1 = await this.runCommand(["-c", `wc -l ${logs}`]);
     await sleep(2000);
-    const lines_2 = await this.runCommand([
-      "-c",
-      `wc -l ${logs}`,
-    ]);
+    const lines_2 = await this.runCommand(["-c", `wc -l ${logs}`]);
     if (parseInt(lines_2.stdout.trim()) > parseInt(lines_1.stdout.trim()))
       return;
     await sleep(6000);
-    const lines_3 = await this.runCommand([
-      "-c",
-      `wc -l ${logs}`,
-    ]);
+    const lines_3 = await this.runCommand(["-c", `wc -l ${logs}`]);
     if (parseInt(lines_3.stdout.trim()) > parseInt(lines_1.stdout.trim()))
       return;
 
     await sleep(12000);
-    const lines_4 = await this.runCommand([
-      "-c",
-      `wc -l ${logs}`,
-    ]);
+    const lines_4 = await this.runCommand(["-c", `wc -l ${logs}`]);
     if (parseInt(lines_4.stdout.trim()) > parseInt(lines_1.stdout.trim()))
       return;
 

--- a/javascript/packages/orchestrator/src/providers/native/nativeClient.ts
+++ b/javascript/packages/orchestrator/src/providers/native/nativeClient.ts
@@ -352,7 +352,7 @@ export class NativeClient extends Client {
     const { pid, logs } = procNodeName;
     const result = await this.runCommand([
       "-c",
-      `ps ${this.processMap[nodeName].pid}`,
+      `ps ${pid}`,
     ]);
     if (result.exitCode > 0)
       throw new Error(

--- a/javascript/packages/orchestrator/src/providers/native/nativeClient.ts
+++ b/javascript/packages/orchestrator/src/providers/native/nativeClient.ts
@@ -374,7 +374,7 @@ export class NativeClient extends Client {
     await sleep(6000);
     const lines_3 = await this.runCommand([
       "-c",
-      `wc -l ${this.processMap[nodeName].logs}`,
+      `wc -l ${logs}`,
     ]);
     if (parseInt(lines_3.stdout.trim()) > parseInt(lines_1.stdout.trim()))
       return;

--- a/javascript/packages/orchestrator/src/providers/native/nativeClient.ts
+++ b/javascript/packages/orchestrator/src/providers/native/nativeClient.ts
@@ -367,7 +367,7 @@ export class NativeClient extends Client {
     await sleep(2000);
     const lines_2 = await this.runCommand([
       "-c",
-      `wc -l ${this.processMap[nodeName].logs}`,
+      `wc -l ${logs}`,
     ]);
     if (parseInt(lines_2.stdout.trim()) > parseInt(lines_1.stdout.trim()))
       return;

--- a/javascript/packages/orchestrator/src/providers/native/nativeClient.ts
+++ b/javascript/packages/orchestrator/src/providers/native/nativeClient.ts
@@ -362,7 +362,7 @@ export class NativeClient extends Client {
     // check log lines grow between 2/6/12 secs
     const lines_1 = await this.runCommand([
       "-c",
-      `wc -l ${this.processMap[nodeName].logs}`,
+      `wc -l ${logs}`,
     ]);
     await sleep(2000);
     const lines_2 = await this.runCommand([

--- a/javascript/packages/orchestrator/src/providers/native/nativeClient.ts
+++ b/javascript/packages/orchestrator/src/providers/native/nativeClient.ts
@@ -382,7 +382,7 @@ export class NativeClient extends Client {
     await sleep(12000);
     const lines_4 = await this.runCommand([
       "-c",
-      `wc -l ${this.processMap[nodeName].logs}`,
+      `wc -l ${logs}`,
     ]);
     if (parseInt(lines_4.stdout.trim()) > parseInt(lines_1.stdout.trim()))
       return;


### PR DESCRIPTION
- refactor the logic to verify that the node is ready:
  - First check if the `pid`   is running
  - Check if the logs lines grow
  
  fix #516 