### PR TITLE
`native` - check launch error on native provider

### DIFF
--- a/javascript/packages/orchestrator/src/providers/client.ts
+++ b/javascript/packages/orchestrator/src/providers/client.ts
@@ -3,6 +3,8 @@ import { fileMap } from "../types";
 export interface RunCommandResponse {
   exitCode: number;
   stdout: string;
+  stderr?: string;
+  errorMsg?: string;
 }
 
 export abstract class Client {
@@ -52,6 +54,7 @@ export abstract class Client {
     args: string[],
     resourceDef?: string,
     scoped?: boolean,
+    allowFail?: boolean,
   ): Promise<RunCommandResponse>;
   abstract runScript(
     identifier: string,

--- a/javascript/packages/orchestrator/src/providers/native/nativeClient.ts
+++ b/javascript/packages/orchestrator/src/providers/native/nativeClient.ts
@@ -163,12 +163,16 @@ export class NativeClient extends Client {
     return ["127.0.0.1", hostPort];
   }
 
-  async runCommand(args: string[], _resourceDef?: string, _scoped?: boolean, allowFail?: boolean): Promise<RunCommandResponse> {
-    let result;
+  async runCommand(
+    args: string[],
+    _resourceDef?: string,
+    _scoped?: boolean,
+    allowFail?: boolean,
+  ): Promise<RunCommandResponse> {
     try {
       if (args[0] === "bash") args.splice(0, 1);
       debug(args);
-      result = await execa(this.command, args);
+      const result = await execa(this.command, args);
 
       // podman use stderr for logs
       const stdout =
@@ -184,16 +188,15 @@ export class NativeClient extends Client {
       };
     } catch (error: any) {
       debug(error);
-      if(!allowFail) throw error;
+      if (!allowFail) throw error;
 
       const { exitCode, stdout, message: errorMsg } = error;
 
       return {
         exitCode,
         stdout,
-        errorMsg
-      }
-
+        errorMsg,
+      };
     }
   }
 
@@ -360,7 +363,12 @@ export class NativeClient extends Client {
     await sleep(1000);
     const procNodeName = this.processMap[nodeName];
     const { pid, logs } = procNodeName;
-    const result = await this.runCommand(["-c", `ps ${pid}`], undefined, undefined, true);
+    const result = await this.runCommand(
+      ["-c", `ps ${pid}`],
+      undefined,
+      undefined,
+      true,
+    );
     if (result.exitCode > 0) {
       const lines = await this.getNodeLogs(nodeName);
 

--- a/javascript/packages/orchestrator/src/providers/native/nativeClient.ts
+++ b/javascript/packages/orchestrator/src/providers/native/nativeClient.ts
@@ -163,11 +163,12 @@ export class NativeClient extends Client {
     return ["127.0.0.1", hostPort];
   }
 
-  async runCommand(args: string[]): Promise<RunCommandResponse> {
+  async runCommand(args: string[], _resourceDef?: string, _scoped?: boolean, allowFail?: boolean): Promise<RunCommandResponse> {
+    let result;
     try {
       if (args[0] === "bash") args.splice(0, 1);
       debug(args);
-      const result = await execa(this.command, args);
+      result = await execa(this.command, args);
 
       // podman use stderr for logs
       const stdout =
@@ -181,9 +182,18 @@ export class NativeClient extends Client {
         exitCode: result.exitCode,
         stdout,
       };
-    } catch (error) {
-      console.log(error);
-      throw error;
+    } catch (error: any) {
+      debug(error);
+      if(!allowFail) throw error;
+
+      const { exitCode, stdout, message: errorMsg } = error;
+
+      return {
+        exitCode,
+        stdout,
+        errorMsg
+      }
+
     }
   }
 
@@ -350,9 +360,27 @@ export class NativeClient extends Client {
     await sleep(1000);
     const procNodeName = this.processMap[nodeName];
     const { pid, logs } = procNodeName;
-    const result = await this.runCommand(["-c", `ps ${pid}`]);
-    if (result.exitCode > 0)
-      throw new Error(`Process: ${pid}, for node: ${nodeName} dies`);
+    const result = await this.runCommand(["-c", `ps ${pid}`], undefined, undefined, true);
+    if (result.exitCode > 0) {
+      const lines = await this.getNodeLogs(nodeName);
+
+      let logTable = new CreateLogTable({
+        colWidths: [20, 100],
+      });
+
+      logTable.pushToPrint([
+        [decorators.cyan("Pod"), decorators.green(nodeName)],
+        [decorators.cyan("Status"), decorators.red("Error")],
+        [
+          decorators.cyan("Message"),
+          decorators.white(`Process: ${pid}, for node: ${nodeName} dies.`),
+        ],
+        [decorators.cyan("Output"), decorators.white(lines)],
+      ]);
+
+      // throw
+      throw new Error();
+    }
 
     // check log lines grow between 2/6/12 secs
     const lines_1 = await this.runCommand(["-c", `wc -l ${logs}`]);


### PR DESCRIPTION
- Check if the process is alive and show the log output in case if `die`

fixes #466

Example:
<img width="988" alt="image" src="https://user-images.githubusercontent.com/363911/206541361-e36c7dcd-96e0-4f05-9465-c25ffa4d0aa6.png">
