### PR TITLE
feature: support pause/resume for native provider

### DIFF
--- a/javascript/packages/orchestrator/src/providers/client.ts
+++ b/javascript/packages/orchestrator/src/providers/client.ts
@@ -86,6 +86,10 @@ export abstract class Client {
   abstract createPodMonitor(filename: string, chain: string): Promise<void>;
   abstract setupCleaner(): Promise<any>;
   abstract isPodMonitorAvailable(): Promise<boolean>;
+
+  abstract getPauseArgs(name: string): string[];
+  abstract getResumeArgs(name: string): string[];
+  abstract restartNode(name: string, timeout: number | null): Promise<boolean>;
 }
 
 let client: Client;

--- a/javascript/packages/orchestrator/src/providers/k8s/kubeClient.ts
+++ b/javascript/packages/orchestrator/src/providers/k8s/kubeClient.ts
@@ -722,6 +722,24 @@ export class KubeClient extends Client {
     }
   }
 
+  getPauseArgs(name: string): string[] {
+    return ["exec", name, "--", "bash", "-c", "echo pause > /tmp/zombiepipe"];
+  }
+  getResumeArgs(name: string): string[] {
+    return ["exec", name, "--", "bash", "-c", "echo resume > /tmp/zombiepipe"];
+  }
+
+  async restartNode(name: string, timeout: number | null): Promise<boolean> {
+    const args = ["exec", name, "--", "bash", "-c"];
+    const cmd = timeout
+      ? `echo restart ${timeout} > /tmp/zombiepipe`
+      : `echo restart > /tmp/zombiepipe`;
+    args.push(cmd);
+
+    const result = await this.runCommand(args, { scoped: true });
+    return result.exitCode === 0;
+  }
+
   async spawnIntrospector(wsUri: string) {
     await this.createStaticResource("introspector-pod.yaml", this.namespace, {
       WS_URI: wsUri,

--- a/javascript/packages/orchestrator/src/providers/native/nativeClient.ts
+++ b/javascript/packages/orchestrator/src/providers/native/nativeClient.ts
@@ -57,6 +57,7 @@ export class NativeClient extends Client {
         // 9944 : 56045
         [original: number]: number;
       };
+      cmd?: string[];
     };
   };
 
@@ -358,6 +359,7 @@ export class NativeClient extends Client {
       nodeProcess.stdout.pipe(log);
       nodeProcess.stderr.pipe(log);
       this.processMap[name].pid = nodeProcess.pid;
+      this.processMap[name].cmd = resourseDef.spec.command;
 
       await this.wait_node_ready(name);
     }
@@ -419,5 +421,42 @@ export class NativeClient extends Client {
   async isPodMonitorAvailable(): Promise<boolean> {
     // NOOP
     return false;
+  }
+
+  getPauseArgs(name: string): string[] {
+    return ["-c", `kill -STOP ${this.processMap[name].pid!.toString()}`];
+  }
+
+  getResumeArgs(name: string): string[] {
+    return ["-c", `kill -CONT ${this.processMap[name].pid!.toString()}`];
+  }
+
+  async restartNode(name: string, timeout: number | null): Promise<boolean> {
+    // kill
+    const result = await this.runCommand(
+      ["-c", `kill -9 ${this.processMap[name].pid!.toString()}`],
+      { allowFail: true },
+    );
+    if (result.exitCode !== 0) return false;
+
+    // sleep
+    if (timeout) await sleep(timeout * 1000);
+
+    // start
+    const log = fs.createWriteStream(this.processMap[name].logs);
+    console.log(["-c", ...this.processMap[name].cmd!]);
+    const nodeProcess = spawn(this.command, [
+      "-c",
+      ...this.processMap[name].cmd!,
+    ]);
+    debug(nodeProcess.pid);
+    nodeProcess.stdout.pipe(log);
+    nodeProcess.stderr.pipe(log);
+    this.processMap[name].pid = nodeProcess.pid;
+
+    await this.wait_node_ready(name);
+
+    console.log("true");
+    return true;
   }
 }

--- a/javascript/packages/orchestrator/src/providers/native/nativeClient.ts
+++ b/javascript/packages/orchestrator/src/providers/native/nativeClient.ts
@@ -455,8 +455,6 @@ export class NativeClient extends Client {
     this.processMap[name].pid = nodeProcess.pid;
 
     await this.wait_node_ready(name);
-
-    console.log("true");
     return true;
   }
 }

--- a/javascript/packages/orchestrator/src/providers/podman/podmanClient.ts
+++ b/javascript/packages/orchestrator/src/providers/podman/podmanClient.ts
@@ -477,6 +477,24 @@ export class PodmanClient extends Client {
     return false;
   }
 
+  getPauseArgs(name: string): string[] {
+    return ["exec", name, "--", "bash", "-c", "echo pause > /tmp/zombiepipe"];
+  }
+  getResumeArgs(name: string): string[] {
+    return ["exec", name, "--", "bash", "-c", "echo resume > /tmp/zombiepipe"];
+  }
+
+  async restartNode(name: string, timeout: number | null): Promise<boolean> {
+    const args = ["exec", name, "--", "bash", "-c"];
+    const cmd = timeout
+      ? `echo restart ${timeout} > /tmp/zombiepipe`
+      : `echo restart > /tmp/zombiepipe`;
+    args.push(cmd);
+
+    const result = await this.runCommand(args, { scoped: true });
+    return result.exitCode === 0;
+  }
+
   async spawnIntrospector(wsUri: string) {
     const spec = await getIntrospectorDef(this.namespace, wsUri);
     await this.createResource(spec, false, true);


### PR DESCRIPTION
fixes #669 

- Add support for `restart`/ `pause` / `resume` for native provider.
- Move logic to each provider (restart/pause/resume).