### PR TITLE
move commander dependency from util to cli

### DIFF
--- a/javascript/package-lock.json
+++ b/javascript/package-lock.json
@@ -1402,14 +1402,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/commander": {
-      "version": "9.4.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-9.4.1.tgz",
-      "integrity": "sha512-5EEkTNyHNGFPD2H+c/dXXfQZYa/scCKasxWcXJaWnNJ99pnQN9Vnmqow+p+PlFPE63Q6mThaZws1T+HxfpgtPw==",
-      "engines": {
-        "node": "^12.20.0 || >=14"
-      }
-    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -2873,24 +2865,23 @@
       "dev": true
     },
     "node_modules/napi-maybe-compressed-blob": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/napi-maybe-compressed-blob/-/napi-maybe-compressed-blob-0.0.7.tgz",
-      "integrity": "sha512-NfzpmH5JOjxl1y9zNFrEHYRYIAbpVp4ulM5+qZU5ElPYX84ySMyTcq2dppGdWYoJaDHAF7NlAcD6zLhB2YsBdA==",
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/napi-maybe-compressed-blob/-/napi-maybe-compressed-blob-0.0.11.tgz",
+      "integrity": "sha512-1dj4ET34TfEes0+josVLvwpJe337Jk6txd3XUjVmVs3budSo2eEjvN6pX4myYE1pS4x/k2Av57n/ypRl2u++AQ==",
       "engines": {
         "node": ">= 10"
       },
       "optionalDependencies": {
-        "napi-maybe-compressed-blob-darwin-arm64": "0.0.7",
-        "napi-maybe-compressed-blob-darwin-x64": "0.0.7",
-        "napi-maybe-compressed-blob-linux-arm64-gnu": "0.0.7",
-        "napi-maybe-compressed-blob-linux-x64-gnu": "0.0.7",
-        "napi-maybe-compressed-blob-win32-x64-msvc": "0.0.7"
+        "napi-maybe-compressed-blob-darwin-arm64": "0.0.11",
+        "napi-maybe-compressed-blob-darwin-x64": "0.0.11",
+        "napi-maybe-compressed-blob-linux-arm64-gnu": "0.0.11",
+        "napi-maybe-compressed-blob-linux-x64-gnu": "0.0.11"
       }
     },
     "node_modules/napi-maybe-compressed-blob-darwin-arm64": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/napi-maybe-compressed-blob-darwin-arm64/-/napi-maybe-compressed-blob-darwin-arm64-0.0.7.tgz",
-      "integrity": "sha512-RVBWPP4SF4vLANKjWPWtq5cZb3j1EyJl2Ttw6TVhdNPkJBM3WQoBT4b57kJum/hQadsxccftWrvbuIdiXpP37g==",
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/napi-maybe-compressed-blob-darwin-arm64/-/napi-maybe-compressed-blob-darwin-arm64-0.0.11.tgz",
+      "integrity": "sha512-hZ9ye4z8iMDVPEnx9A/Ag6k7xHX/BcK5Lntw/VANBUm9ioLSuRvHTALG4XaqVDGXo4U2NFDwSLRDyhFPYvqckQ==",
       "cpu": [
         "arm64"
       ],
@@ -2903,9 +2894,9 @@
       }
     },
     "node_modules/napi-maybe-compressed-blob-darwin-x64": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/napi-maybe-compressed-blob-darwin-x64/-/napi-maybe-compressed-blob-darwin-x64-0.0.7.tgz",
-      "integrity": "sha512-Jry++OTrkgutduswu0MNgFM1t84ExxNidFGvlgR9fNg2U1bQ9OeD/fJvWZwAdLS6DtudGmFFwl9UUp5dhkQkoA==",
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/napi-maybe-compressed-blob-darwin-x64/-/napi-maybe-compressed-blob-darwin-x64-0.0.11.tgz",
+      "integrity": "sha512-TqWNP7Vehi73xLXyUGjdLppP0W6T0Ef2D/X9HmAZNwglt+MkTujX10CDODfbFWvGy+NkaC5XqnzxCn19wbZZcA==",
       "cpu": [
         "x64"
       ],
@@ -2918,9 +2909,9 @@
       }
     },
     "node_modules/napi-maybe-compressed-blob-linux-arm64-gnu": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/napi-maybe-compressed-blob-linux-arm64-gnu/-/napi-maybe-compressed-blob-linux-arm64-gnu-0.0.7.tgz",
-      "integrity": "sha512-HWF0AWNa5gyCXUM5uE8bmeAUqF7n0rgW76bVuJ6NaADx3qWSCJOUSYpB1bV7xINRPswcJglzRIv6A3yn60JyKQ==",
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/napi-maybe-compressed-blob-linux-arm64-gnu/-/napi-maybe-compressed-blob-linux-arm64-gnu-0.0.11.tgz",
+      "integrity": "sha512-7D5w6MDZghcb3VtXRg2ShCEh9Z3zMeBVRG4xsMulEWT2j9/09Nopu+9KfI/2ngRvm78MniWSIlqds5PRAlCROA==",
       "cpu": [
         "arm64"
       ],
@@ -2933,9 +2924,9 @@
       }
     },
     "node_modules/napi-maybe-compressed-blob-linux-x64-gnu": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/napi-maybe-compressed-blob-linux-x64-gnu/-/napi-maybe-compressed-blob-linux-x64-gnu-0.0.7.tgz",
-      "integrity": "sha512-/9E3bcKUXCAPZVVQHAmNJiWh9E6iM/o58QbOqHuzFcLV+QIDh8EgqDovC3V6sVlvL3zQ/dMwXDB6cylLjPaGYg==",
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/napi-maybe-compressed-blob-linux-x64-gnu/-/napi-maybe-compressed-blob-linux-x64-gnu-0.0.11.tgz",
+      "integrity": "sha512-JKY8KcZpQtKiL1smMKfukcOmsDVeZaw9fKXKsWC+wySc2wsvH7V2wy8PffSQ0lWERkI7Yn3k7xPjB463m/VNtg==",
       "cpu": [
         "x64"
       ],
@@ -4506,13 +4497,14 @@
     },
     "packages/cli": {
       "name": "@zombienet/cli",
-      "version": "1.3.23",
+      "version": "1.3.29",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@zombienet/dsl-parser-wrapper": "^0.1.7",
-        "@zombienet/orchestrator": "^0.0.15",
-        "@zombienet/utils": "^0.0.12",
+        "@zombienet/orchestrator": "^0.0.21",
+        "@zombienet/utils": "^0.0.13",
         "axios": "^0.27.2",
+        "commander": "^10.0.0",
         "debug": "^4.3.2",
         "nunjucks": "^3.2.3",
         "progress": "^2.0.3",
@@ -4530,15 +4522,23 @@
         "node": ">=16"
       }
     },
+    "packages/cli/node_modules/commander": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.0.tgz",
+      "integrity": "sha512-zS5PnTI22FIRM6ylNW8G4Ap0IEOyk62fhLSD0+uHRT9McRCLGpkVNvao4bjimpK/GShynyQkFFxHhwMcETmduA==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "packages/orchestrator": {
       "name": "@zombienet/orchestrator",
-      "version": "0.0.15",
+      "version": "0.0.21",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@polkadot/api": "^9.2.4",
         "@polkadot/keyring": "^10.1.6",
         "@polkadot/util-crypto": "^10.1.6",
-        "@zombienet/utils": "^0.0.11",
+        "@zombienet/utils": "^0.0.13",
         "axios": "^0.27.2",
         "chai": "^4.3.4",
         "debug": "^4.3.2",
@@ -4550,7 +4550,7 @@
         "libp2p-crypto": "^0.21.2",
         "minimatch": "^5.1.0",
         "mocha": "^10.0.0",
-        "napi-maybe-compressed-blob": "^0.0.7",
+        "napi-maybe-compressed-blob": "^0.0.11",
         "peer-id": "^0.16.0",
         "tmp-promise": "^3.0.2",
         "typescript": "^4.8.2",
@@ -4564,27 +4564,13 @@
         "@types/mocha": "^9.0.0"
       }
     },
-    "packages/orchestrator/node_modules/@zombienet/utils": {
-      "version": "0.0.11",
-      "resolved": "https://registry.npmjs.org/@zombienet/utils/-/utils-0.0.11.tgz",
-      "integrity": "sha512-wPjziFtlmGimt694is5kOUGbmbx/UNhEyYLRlqX6tfF4rkXsMMFnVQMZIqUTcudPurzZx4R/p78sEjy35t/Cmw==",
-      "dependencies": {
-        "axios": "^0.27.2",
-        "cli-table3": "^0.6.2",
-        "commander": "^9.4.0",
-        "debug": "^4.3.2",
-        "nunjucks": "^3.2.3",
-        "toml": "^3.0.0"
-      }
-    },
     "packages/utils": {
       "name": "@zombienet/utils",
-      "version": "0.0.12",
+      "version": "0.0.13",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "axios": "^0.27.2",
         "cli-table3": "^0.6.2",
-        "commander": "^9.4.0",
         "debug": "^4.3.2",
         "nunjucks": "^3.2.3",
         "toml": "^3.0.0"
@@ -5276,14 +5262,22 @@
         "@types/nunjucks": "^3.2.1",
         "@types/progress": "^2.0.5",
         "@zombienet/dsl-parser-wrapper": "^0.1.7",
-        "@zombienet/orchestrator": "^0.0.15",
-        "@zombienet/utils": "^0.0.12",
+        "@zombienet/orchestrator": "^0.0.21",
+        "@zombienet/utils": "^0.0.13",
         "axios": "^0.27.2",
+        "commander": "^10.0.0",
         "debug": "^4.3.2",
         "nunjucks": "^3.2.3",
         "pkg": "~5.8.0",
         "progress": "^2.0.3",
         "typescript": "^4.8.2"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "10.0.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.0.tgz",
+          "integrity": "sha512-zS5PnTI22FIRM6ylNW8G4Ap0IEOyk62fhLSD0+uHRT9McRCLGpkVNvao4bjimpK/GShynyQkFFxHhwMcETmduA=="
+        }
       }
     },
     "@zombienet/dsl-parser-wrapper": {
@@ -5302,7 +5296,7 @@
         "@types/jsdom": "^20.0.0",
         "@types/minimatch": "^5.1.2",
         "@types/mocha": "^9.0.0",
-        "@zombienet/utils": "^0.0.11",
+        "@zombienet/utils": "^0.0.13",
         "axios": "^0.27.2",
         "chai": "^4.3.4",
         "debug": "^4.3.2",
@@ -5314,26 +5308,11 @@
         "libp2p-crypto": "^0.21.2",
         "minimatch": "^5.1.0",
         "mocha": "^10.0.0",
-        "napi-maybe-compressed-blob": "^0.0.7",
+        "napi-maybe-compressed-blob": "^0.0.11",
         "peer-id": "^0.16.0",
         "tmp-promise": "^3.0.2",
         "typescript": "^4.8.2",
         "yaml": "^2.0.0-9"
-      },
-      "dependencies": {
-        "@zombienet/utils": {
-          "version": "0.0.11",
-          "resolved": "https://registry.npmjs.org/@zombienet/utils/-/utils-0.0.11.tgz",
-          "integrity": "sha512-wPjziFtlmGimt694is5kOUGbmbx/UNhEyYLRlqX6tfF4rkXsMMFnVQMZIqUTcudPurzZx4R/p78sEjy35t/Cmw==",
-          "requires": {
-            "axios": "^0.27.2",
-            "cli-table3": "^0.6.2",
-            "commander": "^9.4.0",
-            "debug": "^4.3.2",
-            "nunjucks": "^3.2.3",
-            "toml": "^3.0.0"
-          }
-        }
       }
     },
     "@zombienet/utils": {
@@ -5342,7 +5321,6 @@
         "@types/nunjucks": "^3.2.1",
         "axios": "^0.27.2",
         "cli-table3": "^0.6.2",
-        "commander": "^9.4.0",
         "debug": "^4.3.2",
         "nunjucks": "^3.2.3",
         "toml": "^3.0.0",
@@ -5720,11 +5698,6 @@
       "requires": {
         "delayed-stream": "~1.0.0"
       }
-    },
-    "commander": {
-      "version": "9.4.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-9.4.1.tgz",
-      "integrity": "sha512-5EEkTNyHNGFPD2H+c/dXXfQZYa/scCKasxWcXJaWnNJ99pnQN9Vnmqow+p+PlFPE63Q6mThaZws1T+HxfpgtPw=="
     },
     "concat-map": {
       "version": "0.0.1",
@@ -6801,39 +6774,38 @@
       "dev": true
     },
     "napi-maybe-compressed-blob": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/napi-maybe-compressed-blob/-/napi-maybe-compressed-blob-0.0.7.tgz",
-      "integrity": "sha512-NfzpmH5JOjxl1y9zNFrEHYRYIAbpVp4ulM5+qZU5ElPYX84ySMyTcq2dppGdWYoJaDHAF7NlAcD6zLhB2YsBdA==",
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/napi-maybe-compressed-blob/-/napi-maybe-compressed-blob-0.0.11.tgz",
+      "integrity": "sha512-1dj4ET34TfEes0+josVLvwpJe337Jk6txd3XUjVmVs3budSo2eEjvN6pX4myYE1pS4x/k2Av57n/ypRl2u++AQ==",
       "requires": {
-        "napi-maybe-compressed-blob-darwin-arm64": "0.0.7",
-        "napi-maybe-compressed-blob-darwin-x64": "0.0.7",
-        "napi-maybe-compressed-blob-linux-arm64-gnu": "0.0.7",
-        "napi-maybe-compressed-blob-linux-x64-gnu": "0.0.7",
-        "napi-maybe-compressed-blob-win32-x64-msvc": "0.0.7"
+        "napi-maybe-compressed-blob-darwin-arm64": "0.0.11",
+        "napi-maybe-compressed-blob-darwin-x64": "0.0.11",
+        "napi-maybe-compressed-blob-linux-arm64-gnu": "0.0.11",
+        "napi-maybe-compressed-blob-linux-x64-gnu": "0.0.11"
       }
     },
     "napi-maybe-compressed-blob-darwin-arm64": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/napi-maybe-compressed-blob-darwin-arm64/-/napi-maybe-compressed-blob-darwin-arm64-0.0.7.tgz",
-      "integrity": "sha512-RVBWPP4SF4vLANKjWPWtq5cZb3j1EyJl2Ttw6TVhdNPkJBM3WQoBT4b57kJum/hQadsxccftWrvbuIdiXpP37g==",
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/napi-maybe-compressed-blob-darwin-arm64/-/napi-maybe-compressed-blob-darwin-arm64-0.0.11.tgz",
+      "integrity": "sha512-hZ9ye4z8iMDVPEnx9A/Ag6k7xHX/BcK5Lntw/VANBUm9ioLSuRvHTALG4XaqVDGXo4U2NFDwSLRDyhFPYvqckQ==",
       "optional": true
     },
     "napi-maybe-compressed-blob-darwin-x64": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/napi-maybe-compressed-blob-darwin-x64/-/napi-maybe-compressed-blob-darwin-x64-0.0.7.tgz",
-      "integrity": "sha512-Jry++OTrkgutduswu0MNgFM1t84ExxNidFGvlgR9fNg2U1bQ9OeD/fJvWZwAdLS6DtudGmFFwl9UUp5dhkQkoA==",
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/napi-maybe-compressed-blob-darwin-x64/-/napi-maybe-compressed-blob-darwin-x64-0.0.11.tgz",
+      "integrity": "sha512-TqWNP7Vehi73xLXyUGjdLppP0W6T0Ef2D/X9HmAZNwglt+MkTujX10CDODfbFWvGy+NkaC5XqnzxCn19wbZZcA==",
       "optional": true
     },
     "napi-maybe-compressed-blob-linux-arm64-gnu": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/napi-maybe-compressed-blob-linux-arm64-gnu/-/napi-maybe-compressed-blob-linux-arm64-gnu-0.0.7.tgz",
-      "integrity": "sha512-HWF0AWNa5gyCXUM5uE8bmeAUqF7n0rgW76bVuJ6NaADx3qWSCJOUSYpB1bV7xINRPswcJglzRIv6A3yn60JyKQ==",
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/napi-maybe-compressed-blob-linux-arm64-gnu/-/napi-maybe-compressed-blob-linux-arm64-gnu-0.0.11.tgz",
+      "integrity": "sha512-7D5w6MDZghcb3VtXRg2ShCEh9Z3zMeBVRG4xsMulEWT2j9/09Nopu+9KfI/2ngRvm78MniWSIlqds5PRAlCROA==",
       "optional": true
     },
     "napi-maybe-compressed-blob-linux-x64-gnu": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/napi-maybe-compressed-blob-linux-x64-gnu/-/napi-maybe-compressed-blob-linux-x64-gnu-0.0.7.tgz",
-      "integrity": "sha512-/9E3bcKUXCAPZVVQHAmNJiWh9E6iM/o58QbOqHuzFcLV+QIDh8EgqDovC3V6sVlvL3zQ/dMwXDB6cylLjPaGYg==",
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/napi-maybe-compressed-blob-linux-x64-gnu/-/napi-maybe-compressed-blob-linux-x64-gnu-0.0.11.tgz",
+      "integrity": "sha512-JKY8KcZpQtKiL1smMKfukcOmsDVeZaw9fKXKsWC+wySc2wsvH7V2wy8PffSQ0lWERkI7Yn3k7xPjB463m/VNtg==",
       "optional": true
     },
     "next-tick": {

--- a/javascript/packages/cli/package.json
+++ b/javascript/packages/cli/package.json
@@ -56,6 +56,7 @@
     "@zombienet/orchestrator": "^0.0.21",
     "@zombienet/utils": "^0.0.13",
     "axios": "^0.27.2",
+    "commander": "^10.0.0",
     "debug": "^4.3.2",
     "nunjucks": "^3.2.3",
     "progress": "^2.0.3",

--- a/javascript/packages/utils/package.json
+++ b/javascript/packages/utils/package.json
@@ -29,7 +29,6 @@
   "dependencies": {
     "axios": "^0.27.2",
     "cli-table3": "^0.6.2",
-    "commander": "^9.4.0",
     "debug": "^4.3.2",
     "nunjucks": "^3.2.3",
     "toml": "^3.0.0"


### PR DESCRIPTION
Commander is used in cli package but is set as a dependency of utils.
This causes fallback to older versions when the package is used outside of the monorepo and a project already has an older version of Commander as a direct or indirect dependency. 
