### PR TITLE
Fix 704 podman ports

### DIFF
--- a/javascript/packages/orchestrator/src/configGenerator.ts
+++ b/javascript/packages/orchestrator/src/configGenerator.ts
@@ -411,15 +411,7 @@ export async function generateNetworkSpec(
 export async function generateBootnodeSpec(
   config: ComputedNetwork,
 ): Promise<Node> {
-  const ports =
-    config.settings.provider !== "native"
-      ? DEFAULT_PORTS
-      : {
-          p2pPort: await getRandomPort(),
-          wsPort: await getRandomPort(),
-          rpcPort: await getRandomPort(),
-          prometheusPort: await getRandomPort(),
-        };
+  const ports = await getPorts(config.settings.provider, {});
 
   const nodeSetup: Node = {
     name: "bootnode",
@@ -513,16 +505,7 @@ async function getCollatorNodeFromConfig(
   const [decoratedKeysGenerator] = decorate(para, [generateKeyForNode]);
   const accountsForNode = await decoratedKeysGenerator(collatorName);
 
-  const ports =
-    networkSpec.settings.provider !== "native"
-      ? DEFAULT_PORTS
-      : {
-          p2pPort: collatorConfig.p2p_port || (await getRandomPort()),
-          wsPort: collatorConfig.ws_port || (await getRandomPort()),
-          rpcPort: collatorConfig.rpc_port || (await getRandomPort()),
-          prometheusPort:
-            collatorConfig.prometheus_port || (await getRandomPort()),
-        };
+  const ports = await getPorts(networkSpec.settings.provider, collatorConfig);
 
   const node: Node = {
     name: collatorName,
@@ -594,15 +577,7 @@ async function getNodeFromConfig(
 
   const nodeName = getUniqueName(node.name);
   const accountsForNode = await generateKeyForNode(nodeName);
-  const ports =
-    networkSpec.settings.provider !== "native"
-      ? DEFAULT_PORTS
-      : {
-          p2pPort: node.p2p_port || (await getRandomPort()),
-          wsPort: node.ws_port || (await getRandomPort()),
-          rpcPort: node.rpc_port || (await getRandomPort()),
-          prometheusPort: node.prometheus_port || (await getRandomPort()),
-        };
+  const ports = await getPorts(networkSpec.settings.provider, node);
 
   // build node Setup
   const nodeSetup: Node = {
@@ -670,4 +645,21 @@ function sanitizeArgs(
     });
 
   return filteredArgs;
+}
+
+
+async function getPorts(provider: string, nodeSetup: any): Promise<any> {
+
+  let ports = DEFAULT_PORTS;
+
+  if( provider === "native" || provider === "podman") {
+    ports = {
+      p2pPort: nodeSetup.p2p_port || (await getRandomPort()),
+      wsPort: nodeSetup.ws_port || (await getRandomPort()),
+      rpcPort: nodeSetup.rpc_port || (await getRandomPort()),
+      prometheusPort: nodeSetup.prometheus_port || (await getRandomPort()),
+    }
+  }
+
+  return ports;
 }

--- a/javascript/packages/orchestrator/src/configGenerator.ts
+++ b/javascript/packages/orchestrator/src/configGenerator.ts
@@ -436,7 +436,7 @@ export async function generateBootnodeSpec(
     zombieRole: "bootnode",
     imagePullPolicy: config.settings.image_pull_policy || "Always",
     ...ports,
-    externalPorts
+    externalPorts,
   };
 
   return nodeSetup;
@@ -532,7 +532,7 @@ async function getCollatorNodeFromConfig(
     parachainId: para_id,
     imagePullPolicy: networkSpec.settings.image_pull_policy || "Always",
     ...ports,
-    externalPorts
+    externalPorts,
   };
 
   return node;
@@ -614,7 +614,7 @@ async function getNodeFromConfig(
     zombieRole: "node",
     imagePullPolicy: networkSpec.settings.image_pull_policy || "Always",
     ...ports,
-    externalPorts
+    externalPorts,
   };
 
   if (group) nodeSetup.group = group;
@@ -657,32 +657,34 @@ function sanitizeArgs(
   return filteredArgs;
 }
 
-
 async function getPorts(provider: string, nodeSetup: any): Promise<any> {
   let ports = DEFAULT_PORTS;
 
-  if( provider === "native") {
+  if (provider === "native") {
     ports = {
       p2pPort: nodeSetup.p2p_port || (await getRandomPort()),
       wsPort: nodeSetup.ws_port || (await getRandomPort()),
       rpcPort: nodeSetup.rpc_port || (await getRandomPort()),
       prometheusPort: nodeSetup.prometheus_port || (await getRandomPort()),
-    }
+    };
   }
 
   return ports;
 }
 
-async function getExternalPorts(provider: string, processPorts: any, nodeSetup: any): Promise<any> {
-
-  if( provider === "native")  return processPorts;
+async function getExternalPorts(
+  provider: string,
+  processPorts: any,
+  nodeSetup: any,
+): Promise<any> {
+  if (provider === "native") return processPorts;
 
   const ports = {
     p2pPort: nodeSetup.p2p_port || (await getRandomPort()),
     wsPort: nodeSetup.ws_port || (await getRandomPort()),
     rpcPort: nodeSetup.rpc_port || (await getRandomPort()),
     prometheusPort: nodeSetup.prometheus_port || (await getRandomPort()),
-  }
+  };
 
   return ports;
 }

--- a/javascript/packages/orchestrator/src/providers/podman/dynResourceDefinition.ts
+++ b/javascript/packages/orchestrator/src/providers/podman/dynResourceDefinition.ts
@@ -396,7 +396,8 @@ async function make_main_container(
   nodeSetup: Node,
   volume_mounts: any[],
 ): Promise<any> {
-  const { rpcPort, wsPort, prometheusPort, p2pPort } = nodeSetup.externalPorts!;
+  // @ts-ignore
+  const { rpcPort, wsPort, prometheusPort, p2pPort } = nodeSetup.externalPorts ? nodeSetup.externalPorts : {};
   const ports = [
     {
       containerPort: PROMETHEUS_PORT,

--- a/javascript/packages/orchestrator/src/providers/podman/dynResourceDefinition.ts
+++ b/javascript/packages/orchestrator/src/providers/podman/dynResourceDefinition.ts
@@ -397,26 +397,30 @@ async function make_main_container(
   volume_mounts: any[],
 ): Promise<any> {
   // @ts-ignore
-  const { rpcPort, wsPort, prometheusPort, p2pPort } = nodeSetup.externalPorts ? nodeSetup.externalPorts : {};
+  const { rpcPort, wsPort, prometheusPort, p2pPort } = nodeSetup.externalPorts
+    ? nodeSetup.externalPorts
+    : {};
   const ports = [
     {
       containerPort: PROMETHEUS_PORT,
       name: "prometheus",
-      hostPort: prometheusPort || await getRandomPort(),
+      hostPort: prometheusPort || (await getRandomPort()),
     },
     {
       containerPort: RPC_HTTP_PORT,
       name: "rpc",
-      hostPort: rpcPort || await getRandomPort(),
+      hostPort: rpcPort || (await getRandomPort()),
     },
     {
       containerPort: RPC_WS_PORT,
       name: "rpc-ws",
-      hostPort: wsPort || await getRandomPort(),
+      hostPort: wsPort || (await getRandomPort()),
     },
-    { containerPort: P2P_PORT,
+    {
+      containerPort: P2P_PORT,
       name: "p2p",
-      hostPort: p2pPort || await getRandomPort() },
+      hostPort: p2pPort || (await getRandomPort()),
+    },
   ];
 
   let computedCommand;

--- a/javascript/packages/orchestrator/src/providers/podman/dynResourceDefinition.ts
+++ b/javascript/packages/orchestrator/src/providers/podman/dynResourceDefinition.ts
@@ -396,7 +396,7 @@ async function make_main_container(
   nodeSetup: Node,
   volume_mounts: any[],
 ): Promise<any> {
-  const { rpcPort, wsPort, prometheusPort, p2pPort } = nodeSetup;
+  const { rpcPort, wsPort, prometheusPort, p2pPort } = nodeSetup.externalPorts!;
   const ports = [
     {
       containerPort: PROMETHEUS_PORT,

--- a/javascript/packages/orchestrator/src/providers/podman/dynResourceDefinition.ts
+++ b/javascript/packages/orchestrator/src/providers/podman/dynResourceDefinition.ts
@@ -396,23 +396,26 @@ async function make_main_container(
   nodeSetup: Node,
   volume_mounts: any[],
 ): Promise<any> {
+  const { rpcPort, wsPort, prometheusPort, p2pPort } = nodeSetup;
   const ports = [
     {
       containerPort: PROMETHEUS_PORT,
       name: "prometheus",
-      hostPort: await getRandomPort(),
+      hostPort: prometheusPort || await getRandomPort(),
     },
     {
       containerPort: RPC_HTTP_PORT,
       name: "rpc",
-      hostPort: await getRandomPort(),
+      hostPort: rpcPort || await getRandomPort(),
     },
     {
       containerPort: RPC_WS_PORT,
       name: "rpc-ws",
-      hostPort: await getRandomPort(),
+      hostPort: wsPort || await getRandomPort(),
     },
-    { containerPort: P2P_PORT, name: "p2p", hostPort: await getRandomPort() },
+    { containerPort: P2P_PORT,
+      name: "p2p",
+      hostPort: p2pPort || await getRandomPort() },
   ];
 
   let computedCommand;

--- a/javascript/packages/orchestrator/src/types.ts
+++ b/javascript/packages/orchestrator/src/types.ts
@@ -174,6 +174,12 @@ export interface Node {
   p2pPort: number;
   imagePullPolicy?: "IfNotPresent" | "Never" | "Always";
   dbSnapshot?: string;
+  externalPorts?: {
+    wsPort: number;
+    rpcPort: number;
+    prometheusPort: number;
+    p2pPort: number;
+  }
 }
 
 export interface Collator {

--- a/javascript/packages/orchestrator/src/types.ts
+++ b/javascript/packages/orchestrator/src/types.ts
@@ -179,7 +179,7 @@ export interface Node {
     rpcPort: number;
     prometheusPort: number;
     p2pPort: number;
-  }
+  };
 }
 
 export interface Collator {


### PR DESCRIPTION
Fix #704 

Allow to specify the `external` port for `podman` and control the access to the containers port.
Will work similar as `native` provider.
