### PR TITLE
fix cleanup k8s

### DIFF
--- a/javascript/packages/orchestrator/src/providers/k8s/kubeClient.ts
+++ b/javascript/packages/orchestrator/src/providers/k8s/kubeClient.ts
@@ -442,12 +442,14 @@ export class KubeClient extends Client {
   }
 
   async destroyNamespace() {
-    await this.runCommand(
-      ["delete", "podmonitor", this.namespace, "-n", "monitoring"],
-      {
-        scoped: false,
-      },
-    );
+    if (this.podMonitorAvailable) {
+      await this.runCommand(
+        ["delete", "podmonitor", this.namespace, "-n", "monitoring"],
+        {
+          scoped: false,
+        },
+      );
+    }
 
     await this.runCommand(["delete", "namespace", this.namespace], {
       scoped: false,


### PR DESCRIPTION
- Move `cronjobs` to the same `namespace` (those are deleted when we delete the namespace).
- Add logic to remove `podMonitor` IFF present.