### PR TITLE
Add CI job to publish docker image description to hub.docker.com

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -155,6 +155,23 @@ publish-docker:
   <<: *publish-refs
   <<: *build-push-docker-image
 
+publish-docker-image-description:
+  stage:                           publish
+  <<:                              *kubernetes-env
+  image:                           paritytech/dockerhub-description
+  variables:
+    DOCKER_USERNAME:               $Docker_Hub_User_Parity
+    DOCKER_PASSWORD:               $Docker_Hub_Pass_Parity
+    README_FILEPATH:               $CI_PROJECT_DIR/scripts/ci/docker/Dockerfile.README.md
+    DOCKERHUB_REPOSITORY:          $IMAGE_NAME
+    SHORT_DESCRIPTION:             "A cli tool to easily spawn ephemeral Polkadot/Substrate networks and perform tests against them"
+  rules:
+  - if: $CI_COMMIT_REF_NAME == "main"
+    changes:
+    - scripts/ci/docker/Dockerfile.README.md
+  script:
+    - cd / && sh entrypoint.sh
+
 zombienet-tests-integration:
   stage: deploy
   <<: *kubernetes-env

--- a/scripts/ci/docker/Dockerfile.README.md
+++ b/scripts/ci/docker/Dockerfile.README.md
@@ -1,0 +1,5 @@
+# Zombienet
+
+A cli tool to easily spawn ephemeral Polkadot/Substrate networks and perform tests against them
+
+### [GitHub](https://github.com/paritytech/zombienet)


### PR DESCRIPTION
Added CI job to publish Docker image description to [hub.docker.com](https://hub.docker.com/r/paritytech/zombienet)
Description can be updated in a `scripts/ci/docker/Dockerfile.README.md` file in a repository root and as soon it will be merged into the `main` branch its content will get published to [hub.docker.com](https://hub.docker.com/r/paritytech/zombienet)

Related https://github.com/paritytech/ci_cd/issues/741