### PR TITLE
fix the multiaddress for bootnodes string

### DIFF
--- a/javascript/packages/orchestrator/src/bootnode.ts
+++ b/javascript/packages/orchestrator/src/bootnode.ts
@@ -29,6 +29,5 @@ export async function generateBootnodeString(
     }p2p/${peerId.toB58String()}`;
   }
 
-  console.log("multiaddress", multiaddress);
   return multiaddress;
 }

--- a/javascript/packages/orchestrator/src/bootnode.ts
+++ b/javascript/packages/orchestrator/src/bootnode.ts
@@ -17,19 +17,18 @@ export async function generateBootnodeString(
   );
   let peerId: PeerId = await PeerId.createFromPrivKey(pair.bytes);
 
-
   const listenIndex = args.findIndex((arg) => arg === "--listen-addr");
   if (listenIndex >= 0) {
     let listenAddrParts = args[listenIndex + 1].split("/");
     listenAddrParts[2] = ip;
     listenAddrParts[4] = port.toString();
-    multiaddress = `${listenAddrParts.join("/")}/p2p/${peerId.toB58String()}`
+    multiaddress = `${listenAddrParts.join("/")}/p2p/${peerId.toB58String()}`;
   } else {
     multiaddress = `/ip4/${ip}/tcp/${port}/${
       useWs ? "ws/" : "/"
     }p2p/${peerId.toB58String()}`;
   }
 
-  console.log("multiaddress",multiaddress);
+  console.log("multiaddress", multiaddress);
   return multiaddress;
 }

--- a/javascript/packages/orchestrator/src/bootnode.ts
+++ b/javascript/packages/orchestrator/src/bootnode.ts
@@ -4,18 +4,32 @@ import PeerId from "peer-id";
 
 export async function generateBootnodeString(
   key: string,
+  args: string[],
   ip: string,
   port: number,
   useWs: boolean = true,
 ): Promise<string> {
+  let multiaddress;
   let pair = await libp2pKeys.generateKeyPairFromSeed(
     "Ed25519",
     hexToU8a(hexAddPrefix(key)),
     1024,
   );
   let peerId: PeerId = await PeerId.createFromPrivKey(pair.bytes);
-  const multiaddress = `/ip4/${ip}/tcp/${port}/${
-    useWs ? "ws/" : "/"
-  }p2p/${peerId.toB58String()}`;
+
+
+  const listenIndex = args.findIndex((arg) => arg === "--listen-addr");
+  if (listenIndex >= 0) {
+    let listenAddrParts = args[listenIndex + 1].split("/");
+    listenAddrParts[2] = ip;
+    listenAddrParts[4] = port.toString();
+    multiaddress = `${listenAddrParts.join("/")}/p2p/${peerId.toB58String()}`
+  } else {
+    multiaddress = `/ip4/${ip}/tcp/${port}/${
+      useWs ? "ws/" : "/"
+    }p2p/${peerId.toB58String()}`;
+  }
+
+  console.log("multiaddress",multiaddress);
   return multiaddress;
 }

--- a/javascript/packages/orchestrator/src/cmdGenerator.ts
+++ b/javascript/packages/orchestrator/src/cmdGenerator.ts
@@ -292,7 +292,7 @@ export async function genCmd(
     args[listenIndex + 1] = listenAddr;
   } else {
     // no --listen-add args
-    args.push(...[`--listen-addr /ip4/0.0.0.0/tcp/${nodeSetup.p2pPort}/ws`]);
+    args.push(...["--listen-addr", `/ip4/0.0.0.0/tcp/${nodeSetup.p2pPort}/ws`]);
   }
 
   // set our base path

--- a/javascript/packages/orchestrator/src/orchestrator.ts
+++ b/javascript/packages/orchestrator/src/orchestrator.ts
@@ -507,7 +507,6 @@ export async function start(
       );
 
       const [nodeIp, nodePort] = await client.getNodeInfo(podDef.metadata.name);
-      console.log("node", node);
       const nodeMultiAddress = await generateBootnodeString(
         node.key!,
         node.args,

--- a/javascript/packages/orchestrator/src/orchestrator.ts
+++ b/javascript/packages/orchestrator/src/orchestrator.ts
@@ -657,7 +657,12 @@ export async function start(
       const [nodeIp, nodePort] = await client.getNodeInfo(firstNode.name);
 
       bootnodes.push(
-        await generateBootnodeString(firstNode.key!, firstNode.args, nodeIp, nodePort),
+        await generateBootnodeString(
+          firstNode.key!,
+          firstNode.args,
+          nodeIp,
+          nodePort,
+        ),
       );
       // add bootnodes to chain spec
       await addBootNodes(chainSpecFullPath, bootnodes);

--- a/javascript/packages/orchestrator/src/orchestrator.ts
+++ b/javascript/packages/orchestrator/src/orchestrator.ts
@@ -507,8 +507,10 @@ export async function start(
       );
 
       const [nodeIp, nodePort] = await client.getNodeInfo(podDef.metadata.name);
+      console.log("node", node);
       const nodeMultiAddress = await generateBootnodeString(
         node.key!,
+        node.args,
         nodeIp,
         nodePort,
       );
@@ -655,7 +657,7 @@ export async function start(
       const [nodeIp, nodePort] = await client.getNodeInfo(firstNode.name);
 
       bootnodes.push(
-        await generateBootnodeString(firstNode.key!, nodeIp, nodePort),
+        await generateBootnodeString(firstNode.key!, firstNode.args, nodeIp, nodePort),
       );
       // add bootnodes to chain spec
       await addBootNodes(chainSpecFullPath, bootnodes);
@@ -712,6 +714,7 @@ export async function start(
           await addBootNodes(parachain.specPath!, [
             await generateBootnodeString(
               firstCollatorNode.key!,
+              firstCollatorNode.args,
               nodeIp,
               nodePort,
             ),


### PR DESCRIPTION
Fix the bootnode string to use same logic used to generate the `--listen-add` value.

cc @melekes 