### PR TITLE
Add checks for polkadot and/or polkadot-parachain `not found` errors

### DIFF
--- a/javascript/packages/orchestrator/package.json
+++ b/javascript/packages/orchestrator/package.json
@@ -36,7 +36,7 @@
     "@polkadot/api": "^9.2.4",
     "@polkadot/keyring": "^10.1.6",
     "@polkadot/util-crypto": "^10.1.6",
-    "@zombienet/utils": "^0.0.15",
+    "@zombienet/utils": "^0.0.16",
     "axios": "^0.27.2",
     "chai": "^4.3.4",
     "debug": "^4.3.2",

--- a/javascript/packages/orchestrator/src/configGenerator.ts
+++ b/javascript/packages/orchestrator/src/configGenerator.ts
@@ -9,6 +9,7 @@ import {
 } from "@zombienet/utils";
 import {
   ARGS_TO_REMOVE,
+  DEFAULT_ADDER_COLLATOR_BIN,
   DEFAULT_BALANCE,
   DEFAULT_CHAIN,
   DEFAULT_CHAIN_SPEC_COMMAND,

--- a/javascript/packages/orchestrator/src/configGenerator.ts
+++ b/javascript/packages/orchestrator/src/configGenerator.ts
@@ -239,7 +239,7 @@ export async function generateNetworkSpec(
       const isCumulusBased =
         parachain.cumulus_based !== undefined
           ? parachain.cumulus_based
-          : ![DEFAULT_COLLATOR_IMAGE, UNDYING_COLLATOR_BIN].includes(
+          : ![DEFAULT_ADDER_COLLATOR_BIN, UNDYING_COLLATOR_BIN].includes(
               getFirstCollatorCommand(parachain),
             );
 

--- a/javascript/packages/orchestrator/src/configGenerator.ts
+++ b/javascript/packages/orchestrator/src/configGenerator.ts
@@ -9,7 +9,6 @@ import {
 } from "@zombienet/utils";
 import {
   ARGS_TO_REMOVE,
-  DEFAULT_ADDER_COLLATOR_BIN,
   DEFAULT_BALANCE,
   DEFAULT_CHAIN,
   DEFAULT_CHAIN_SPEC_COMMAND,
@@ -240,7 +239,7 @@ export async function generateNetworkSpec(
       const isCumulusBased =
         parachain.cumulus_based !== undefined
           ? parachain.cumulus_based
-          : ![DEFAULT_ADDER_COLLATOR_BIN, UNDYING_COLLATOR_BIN].includes(
+          : ![DEFAULT_COLLATOR_IMAGE, UNDYING_COLLATOR_BIN].includes(
               getFirstCollatorCommand(parachain),
             );
 

--- a/javascript/packages/orchestrator/src/orchestrator.ts
+++ b/javascript/packages/orchestrator/src/orchestrator.ts
@@ -8,6 +8,9 @@ import {
   getSha256,
   loadTypeDef,
   makeDir,
+  PARACHAIN_NOT_FOUND,
+  POLKADOT_NOT_FOUND,
+  POLKADOT_NOT_FOUND_DESCRIPTION,
   series,
   sleep,
 } from "@zombienet/utils";
@@ -880,9 +883,18 @@ export async function start(
     );
 
     return network;
-  } catch (error) {
+  } catch (error: any) {
+    let errDetails;
+    if (
+      error?.stderr?.includes(POLKADOT_NOT_FOUND) ||
+      error?.stderr?.includes(PARACHAIN_NOT_FOUND)
+    ) {
+      errDetails = POLKADOT_NOT_FOUND_DESCRIPTION;
+    }
     console.log(
-      `\n ${decorators.red("Error: ")} \t ${decorators.bright(error)}\n`,
+      `${decorators.red("Error: ")} \t ${decorators.bright(
+        error,
+      )}\n\n${decorators.magenta(errDetails)}`,
     );
     if (network) {
       await network.dumpLogs();

--- a/javascript/packages/utils/package.json
+++ b/javascript/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zombienet/utils",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "description": "Useful utilities for ZombieNet Framework",
   "main": "dist/index.js",
   "author": "Parity Technologies <admin@parity.io>",

--- a/javascript/packages/utils/src/error_consts.ts
+++ b/javascript/packages/utils/src/error_consts.ts
@@ -1,0 +1,4 @@
+export const POLKADOT_NOT_FOUND = "polkadot: command not found";
+export const PARACHAIN_NOT_FOUND = "polkadot-parachain: command not found";
+export const POLKADOT_NOT_FOUND_DESCRIPTION =
+  "Use `zombienet setup` and follow the tips for setting up your environment for Zombienet.\nYou can read more details in https://paritytech.github.io/zombienet/cli/setup.html .\n\n";

--- a/javascript/packages/utils/src/index.ts
+++ b/javascript/packages/utils/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./colors";
+export * from "./error_consts";
 export * from "./fs";
 export * from "./misc";
 export * from "./net";


### PR DESCRIPTION
Fixes #388. See screenshot below on respective message:

![image](https://user-images.githubusercontent.com/5408605/223746967-d482dfed-440c-4267-93f3-734c465cab78.png)


Note: This is a nice start on "grouping" the ERROR messages into Utils package