### PR TITLE
[fix] set env for native provider

### DIFF
--- a/javascript/packages/orchestrator/src/configGenerator.ts
+++ b/javascript/packages/orchestrator/src/configGenerator.ts
@@ -494,11 +494,9 @@ async function getCollatorNodeFromConfig(
   if (collatorConfig.args)
     args = args.concat(sanitizeArgs(collatorConfig.args, { "listen-addr": 2 }));
 
-  const env = [
-    { name: "COLORBT_SHOW_HIDDEN", value: "1" },
-    { name: "RUST_BACKTRACE", value: "FULL" },
-  ];
-  if (collatorConfig.env) env.push(...collatorConfig.env);
+  const env = collatorConfig.env
+    ? DEFAULT_ENV.concat(collatorConfig.env)
+    : DEFAULT_ENV;
 
   const collatorBinary = collatorConfig.command_with_args
     ? collatorConfig.command_with_args.split(" ")[0]

--- a/javascript/packages/orchestrator/src/providers/native/dynResourceDefinition.ts
+++ b/javascript/packages/orchestrator/src/providers/native/dynResourceDefinition.ts
@@ -8,8 +8,12 @@ import {
   RPC_WS_PORT,
 } from "../../constants";
 import { Network } from "../../network";
-import { Node } from "../../types";
+import { envVars, Node } from "../../types";
 import { getClient } from "../client";
+
+interface processEnvironment {
+  [key: string]: string;
+}
 
 export async function genBootnodeDef(
   namespace: string,
@@ -27,7 +31,6 @@ export async function genBootnodeDef(
   await makeDir(dataPath, true);
 
   const command = await genCmd(nodeSetup, cfgPath, dataPath, false);
-
   return {
     metadata: {
       name: "bootnode",
@@ -44,6 +47,10 @@ export async function genBootnodeDef(
       cfgPath: `${client.tmpDir}/${nodeSetup.name}/cfg`,
       ports,
       command,
+      env: nodeSetup.env.reduce((memo, item: envVars) => {
+        memo[item.name] = item.value;
+        return memo;
+      }, {} as processEnvironment),
     },
   };
 }
@@ -99,6 +106,10 @@ export async function genNodeDef(
       dataPath,
       ports,
       command: computedCommand,
+      env: nodeSetup.env.reduce((memo, item: envVars) => {
+        memo[item.name] = item.value;
+        return memo;
+      }, {} as processEnvironment),
     },
   };
 }

--- a/javascript/packages/orchestrator/src/providers/native/nativeClient.ts
+++ b/javascript/packages/orchestrator/src/providers/native/nativeClient.ts
@@ -358,10 +358,11 @@ export class NativeClient extends Client {
       debug(resourseDef.spec.command);
 
       const log = fs.createWriteStream(this.processMap[name].logs);
-      const nodeProcess = spawn(this.command, [
-        "-c",
-        ...resourseDef.spec.command,
-      ]);
+      const nodeProcess = spawn(
+        this.command,
+        ["-c", ...resourseDef.spec.command],
+        { env: { ...process.env, ...resourseDef.spec.env } },
+      );
       debug(nodeProcess.pid);
       nodeProcess.stdout.pipe(log);
       nodeProcess.stderr.pipe(log);


### PR DESCRIPTION
fix #791 

- Set the `env` for process merging process.env and the `envVars` set in the config.