### PR TITLE
chore: cleaned up unneeded orchestrator exports

### DIFF
--- a/javascript/packages/orchestrator/src/index.ts
+++ b/javascript/packages/orchestrator/src/index.ts
@@ -1,14 +1,4 @@
-export {
-  chainCustomSectionUpgrade,
-  chainUpgradeFromLocalFile,
-  chainUpgradeFromUrl,
-  connect,
-  findPatternInSystemEventSubscription,
-  paraGetBlockHeight,
-  paraIsRegistered,
-  validateRuntimeCode,
-} from "./jsapi-helpers";
-export { Network, rebuildNetwork } from "./network";
+export { Network } from "./network";
 export { start, test } from "./orchestrator";
 export { Providers } from "./providers";
 export { run } from "./test-runner";


### PR DESCRIPTION
Removed unneeded orchestrator exports as explained by #512