### PR TITLE
Reduce the size of the "Network Launched" table

### DIFF
--- a/javascript/packages/orchestrator/src/network.ts
+++ b/javascript/packages/orchestrator/src/network.ts
@@ -285,7 +285,7 @@ export class Network {
           content: decorators.green("Network launched 🚀🚀"),
         },
       ],
-      colWidths: [30, 170],
+      colWidths: [30, 100],
       wordWrap: true,
     });
     logTable.pushTo([


### PR DESCRIPTION
Minor PR for reducing the huge size of the table - no need to extend as much

![image](https://user-images.githubusercontent.com/5408605/226868763-b70db85e-a24b-4749-9550-73015744c4ec.png)
