### PR TITLE
 add p2p_cert_hash config for nodes and logic to build bootnode string

### DIFF
--- a/javascript/packages/orchestrator/src/bootnode.ts
+++ b/javascript/packages/orchestrator/src/bootnode.ts
@@ -8,6 +8,7 @@ export async function generateBootnodeString(
   ip: string,
   port: number,
   useWs: boolean = true,
+  certhash?: string,
 ): Promise<string> {
   let multiaddress;
   let pair = await libp2pKeys.generateKeyPairFromSeed(
@@ -22,6 +23,7 @@ export async function generateBootnodeString(
     let listenAddrParts = args[listenIndex + 1].split("/");
     listenAddrParts[2] = ip;
     listenAddrParts[4] = port.toString();
+    if(certhash) listenAddrParts.push("certhash", certhash);
     multiaddress = `${listenAddrParts.join("/")}/p2p/${peerId.toB58String()}`;
   } else {
     multiaddress = `/ip4/${ip}/tcp/${port}/${

--- a/javascript/packages/orchestrator/src/configGenerator.ts
+++ b/javascript/packages/orchestrator/src/configGenerator.ts
@@ -533,6 +533,7 @@ async function getCollatorNodeFromConfig(
     imagePullPolicy: networkSpec.settings.image_pull_policy || "Always",
     ...ports,
     externalPorts,
+    p2pCertHash: collatorConfig.p2p_cert_hash
   };
 
   return node;
@@ -609,6 +610,7 @@ async function getNodeFromConfig(
     imagePullPolicy: networkSpec.settings.image_pull_policy || "Always",
     ...ports,
     externalPorts,
+    p2pCertHash: node.p2p_cert_hash
   };
 
   if (group) nodeSetup.group = group;

--- a/javascript/packages/orchestrator/src/orchestrator.ts
+++ b/javascript/packages/orchestrator/src/orchestrator.ts
@@ -521,6 +521,8 @@ export async function start(
         node.args,
         nodeIp,
         nodePort,
+        true,
+        node.p2pCertHash
       );
       multiAddressByNode[podDef.metadata.name] = nodeMultiAddress;
 
@@ -668,6 +670,8 @@ export async function start(
           firstNode.args,
           nodeIp,
           nodePort,
+          true,
+          firstNode.p2pCertHash
         ),
       );
       // add bootnodes to chain spec
@@ -729,6 +733,8 @@ export async function start(
               firstCollatorNode.args,
               nodeIp,
               nodePort,
+              true,
+              firstCollatorNode.p2pCertHash
             ),
           ]);
         }

--- a/javascript/packages/orchestrator/src/types.ts
+++ b/javascript/packages/orchestrator/src/types.ts
@@ -76,6 +76,7 @@ export interface NodeConfig {
   prometheus_port?: number;
   p2p_port?: number;
   db_snapshot?: string;
+  p2p_cert_hash?: string; // libp2p certhash to use with webrtc transport.
 }
 
 export interface NodeGroupConfig {
@@ -172,6 +173,7 @@ export interface Node {
   rpcPort: number;
   prometheusPort: number;
   p2pPort: number;
+  p2pCertHash?: string;
   imagePullPolicy?: "IfNotPresent" | "Never" | "Always";
   dbSnapshot?: string;
   externalPorts?: {


### PR DESCRIPTION
Closes #815 

- Add `p2p_cert_hash` config for `NodeConfig`
- Handle logic to add `/certhash/<hash>` to bootnode string when is set.

Thanks!