### PR TITLE
bump npmDepsHash in flake-module.nix

### DIFF
--- a/flake-module.nix
+++ b/flake-module.nix
@@ -15,7 +15,7 @@
         default = pkgs.buildNpmPackage rec {
           # root hash (hash of hashes of each dependnecies)
           # this should be updated on each dependency change (use `prefetch-npm-deps` to get new hash)
-          npmDepsHash = "sha256-kERCSeGAkc0caAahT7fsQzAPL5Bq/rdMgnEhNvCD97I=";
+          npmDepsHash = "sha256-igHqZVtSdg36IBU4mC87UfXZZuqq5HQ6EzmR3iBNrd8=";
 
           pname = "zombienet";
           name = pname;


### PR DESCRIPTION
For the Nix stuff added in #772.

Each time the `javascript/package-lock.json` updates, someone who likes nix should run something like:

```
export NEW_VER=$(nix run nixpkgs#prefetch-npm-deps -- javascript/package-lock.json 2>/dev/null) && \
  sed -i "/npmDepsHash/s/\".*\"/\"$NEW_VER\"/" flake-module.nix
```

to update the value of the `npmDepsHash` in the `flake-module.nix`.