### PR TITLE
[Draft]: Fix podman v4 and refactor

### DIFF
--- a/javascript/packages/orchestrator/src/providers/podman/dynResourceDefinition.ts
+++ b/javascript/packages/orchestrator/src/providers/podman/dynResourceDefinition.ts
@@ -1,49 +1,26 @@
-import { getRandomPort, makeDir } from "@zombienet/utils";
-import { resolve } from "path";
-import { genCmd, genCumulusCollatorCmd } from "../../cmdGenerator";
+import { getRandomPort } from "@zombienet/utils";
 import { getUniqueName } from "../../configGenerator";
-import {
-  INTROSPECTOR_POD_NAME,
-  P2P_PORT,
-  PROMETHEUS_PORT,
-  RPC_HTTP_PORT,
-  RPC_WS_PORT,
-} from "../../constants";
 import { Network } from "../../network";
 import { Node } from "../../types";
 import { getClient } from "../client";
-import { GrafanaResource, IntrospectorResource, NodeResource, PrometheusResource, TempoResource } from "./resources";
-
-const fs = require("fs").promises;
+import {
+  BootNodeResource,
+  GrafanaResource,
+  IntrospectorResource,
+  NodeResource,
+  PrometheusResource,
+  TempoResource,
+} from "./resources";
 
 export async function genBootnodeDef(
   namespace: string,
   nodeSetup: Node,
 ): Promise<any> {
-  const [volume_mounts, devices] = await make_volume_mounts(nodeSetup.name);
-  const container = await make_main_container(nodeSetup, volume_mounts);
-  return {
-    apiVersion: "v1",
-    kind: "Pod",
-    metadata: {
-      name: "bootnode",
-      namespace: namespace,
-      labels: {
-        "app.kubernetes.io/name": namespace,
-        "app.kubernetes.io/instance": "bootnode",
-        "zombie-role": "bootnode",
-        app: "zombienet",
-        "zombie-ns": namespace,
-      },
-    },
-    spec: {
-      hostname: "bootnode",
-      containers: [container],
-      initContainers: [],
-      restartPolicy: "OnFailure",
-      volumes: devices,
-    },
-  };
+  const client = getClient();
+  const bootNodeResource = new BootNodeResource(client, namespace, nodeSetup);
+  const bootNodeResourceSpec = bootNodeResource.generateSpec();
+
+  return bootNodeResourceSpec;
 }
 
 export async function genPrometheusDef(namespace: string): Promise<any> {
@@ -98,84 +75,6 @@ export async function genNodeDef(
   const nodeResourceSpec = nodeResource.generateSpec();
 
   return nodeResourceSpec;
-}
-
-async function make_volume_mounts(name: string): Promise<[any, any]> {
-  const volume_mounts = [
-    { name: "tmp-cfg", mountPath: "/cfg:U", readOnly: false },
-    { name: "tmp-data", mountPath: "/data:U", readOnly: false },
-    { name: "tmp-relay-data", mountPath: "/relay-data:U", readOnly: false },
-  ];
-
-  const client = getClient();
-  const cfgPath = `${client.tmpDir}/${name}/cfg`;
-  const dataPath = `${client.tmpDir}/${name}/data`;
-  const relayDataPath = `${client.tmpDir}/${name}/relay-data`;
-  await makeDir(cfgPath, true);
-  await makeDir(dataPath, true);
-  await makeDir(relayDataPath, true);
-
-  const devices = [
-    { name: "tmp-cfg", hostPath: { type: "Directory", path: cfgPath } },
-    { name: "tmp-data", hostPath: { type: "Directory", path: dataPath } },
-    {
-      name: "tmp-relay-data",
-      hostPath: { type: "Directory", path: relayDataPath },
-    },
-  ];
-
-  return [volume_mounts, devices];
-}
-
-async function make_main_container(
-  nodeSetup: Node,
-  volume_mounts: any[],
-): Promise<any> {
-  // @ts-ignore
-  const { rpcPort, wsPort, prometheusPort, p2pPort } = nodeSetup.externalPorts
-    ? nodeSetup.externalPorts
-    : {};
-  const ports = [
-    {
-      containerPort: PROMETHEUS_PORT,
-      name: "prometheus",
-      hostPort: prometheusPort || (await getRandomPort()),
-    },
-    {
-      containerPort: RPC_HTTP_PORT,
-      name: "rpc",
-      hostPort: rpcPort || (await getRandomPort()),
-    },
-    {
-      containerPort: RPC_WS_PORT,
-      name: "rpc-ws",
-      hostPort: wsPort || (await getRandomPort()),
-    },
-    {
-      containerPort: P2P_PORT,
-      name: "p2p",
-      hostPort: p2pPort || (await getRandomPort()),
-    },
-  ];
-
-  let computedCommand;
-  if (nodeSetup.zombieRole === "cumulus-collator") {
-    computedCommand = await genCumulusCollatorCmd(nodeSetup);
-  } else {
-    computedCommand = await genCmd(nodeSetup);
-  }
-
-  let containerDef = {
-    image: nodeSetup.image,
-    name: nodeSetup.name,
-    imagePullPolicy: "Always",
-    ports,
-    env: nodeSetup.env,
-    volumeMounts: volume_mounts,
-    command: computedCommand,
-  };
-
-  return containerDef;
 }
 
 export function replaceNetworkRef(podDef: any, network: Network) {

--- a/javascript/packages/orchestrator/src/providers/podman/dynResourceDefinition.ts
+++ b/javascript/packages/orchestrator/src/providers/podman/dynResourceDefinition.ts
@@ -12,7 +12,7 @@ import {
 import { Network } from "../../network";
 import { Node } from "../../types";
 import { getClient } from "../client";
-import { GrafanaResource, PrometheusResource, TempoResource } from "./resources";
+import { GrafanaResource, IntrospectorResource, PrometheusResource, TempoResource } from "./resources";
 
 const fs = require("fs").promises;
 
@@ -75,43 +75,10 @@ export async function getIntrospectorDef(
   namespace: string,
   wsUri: string,
 ): Promise<any> {
-  const ports = [
-    {
-      containerPort: 65432,
-      name: "prometheus",
-      hostPort: await getRandomPort(),
-    },
-  ];
+  const introspectorResource = new IntrospectorResource(namespace, wsUri);
+  const introspectorResourceSpec = introspectorResource.generateSpec();
 
-  const containerDef = {
-    image: "docker.io/paritytech/polkadot-introspector:latest",
-    name: INTROSPECTOR_POD_NAME,
-    args: ["block-time-monitor", `--ws=${wsUri}`, "prometheus"],
-    imagePullPolicy: "Always",
-    ports,
-    volumeMounts: [],
-  };
-
-  return {
-    apiVersion: "v1",
-    kind: "Pod",
-    metadata: {
-      name: INTROSPECTOR_POD_NAME,
-      namespace: namespace,
-      labels: {
-        "app.kubernetes.io/name": namespace,
-        "app.kubernetes.io/instance": INTROSPECTOR_POD_NAME,
-        "zombie-role": INTROSPECTOR_POD_NAME,
-        app: "zombienet",
-        "zombie-ns": namespace,
-      },
-    },
-    spec: {
-      hostname: INTROSPECTOR_POD_NAME,
-      containers: [containerDef],
-      restartPolicy: "OnFailure",
-    },
-  };
+  return introspectorResourceSpec;
 }
 
 export async function genTempoDef(namespace: string): Promise<any> {

--- a/javascript/packages/orchestrator/src/providers/podman/resources/boot-node.resource.ts
+++ b/javascript/packages/orchestrator/src/providers/podman/resources/boot-node.resource.ts
@@ -1,0 +1,36 @@
+import { Node } from "../../../types";
+import { Client } from "../../client";
+import { NodeResource } from "./node.resource";
+
+export class BootNodeResource extends NodeResource {
+  constructor(client: Client, namespace: string, nodeSetupConfig: Node) {
+    super(client, namespace, nodeSetupConfig);
+  }
+
+  protected generatePodSpec(containers: any[], volumes: any[]): any {
+    const bootNodePodSpec = {
+      apiVersion: "v1",
+      kind: "Pod",
+      metadata: {
+        name: "bootnode_pod",
+        namespace: this.namespace,
+        labels: {
+          "app.kubernetes.io/name": this.namespace,
+          "app.kubernetes.io/instance": "bootnode",
+          "zombie-role": "bootnode",
+          app: "zombienet",
+          "zombie-ns": this.namespace,
+        },
+      },
+      spec: {
+        hostname: "bootnode",
+        initContainers: [],
+        restartPolicy: "OnFailure",
+        volumes,
+        containers,
+      },
+    };
+
+    return bootNodePodSpec;
+  }
+}

--- a/javascript/packages/orchestrator/src/providers/podman/resources/configs/grafana.yml
+++ b/javascript/packages/orchestrator/src/providers/podman/resources/configs/grafana.yml
@@ -1,0 +1,17 @@
+# config file version
+apiVersion: 1
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    orgId: 1
+    url: http://{{PROMETHEUS_IP}}:9090
+    version: 1
+    editable: true
+  - name: Tempo
+    type: tempo
+    access: proxy
+    orgId: 1
+    url: http://{{TEMPO_IP}}:3200
+    version: 1
+    editable: true

--- a/javascript/packages/orchestrator/src/providers/podman/resources/configs/prometheus.yml
+++ b/javascript/packages/orchestrator/src/providers/podman/resources/configs/prometheus.yml
@@ -1,0 +1,17 @@
+# config
+global:
+  scrape_interval: 5s
+  external_labels:
+    monitor: "zombienet-monitor"
+
+# Scraping Prometheus itself
+scrape_configs:
+  - job_name: "prometheus"
+    static_configs:
+      - targets: ["localhost:9090"]
+  - job_name: "dynamic"
+    file_sd_configs:
+      - files:
+          - /data/sd_config*.yaml
+          - /data/sd_config*.json
+        refresh_interval: 5s

--- a/javascript/packages/orchestrator/src/providers/podman/resources/configs/tempo.yaml
+++ b/javascript/packages/orchestrator/src/providers/podman/resources/configs/tempo.yaml
@@ -1,0 +1,45 @@
+server:
+  http_listen_port: 3100
+
+distributor:
+  receivers:                           # this configuration will listen on all ports and protocols that tempo is capable of.
+    jaeger:                            # the receives all come from the OpenTelemetry collector.  more configuration information can
+      protocols:                       # be found there: https://github.com/open-telemetry/opentelemetry-collector/tree/main/receiver
+        thrift_http:                   #
+        grpc:                          # for a production deployment you should only enable the receivers you need!
+        thrift_binary:
+        thrift_compact:
+    zipkin:
+    otlp:
+      protocols:
+        http:
+        grpc:
+    opencensus:
+
+ingester:
+  trace_idle_period: 10s               # the length of time after a trace has not received spans to consider it complete and flush it
+  max_block_bytes: 1_000_000           # cut the head block when it hits this size or ...
+  max_block_duration: 5m               #   this much time passes
+
+compactor:
+  compaction:
+    compaction_window: 1h              # blocks in this time window will be compacted together
+    max_block_bytes: 100_000_000       # maximum size of compacted blocks
+    block_retention: 1h
+    compacted_block_retention: 10m
+
+storage:
+  trace:
+    backend: local                     # backend configuration to use
+    block:
+      bloom_filter_false_positive: .05 # bloom filter false positive rate.  lower values create larger filters but fewer false positives
+      index_downsample_bytes: 1000     # number of bytes per index record
+      encoding: zstd                   # block encoding/compression.  options: none, gzip, lz4-64k, lz4-256k, lz4-1M, lz4, snappy, zstd, s2
+    wal:
+      path: /tmp/tempo/wal             # where to store the the wal locally
+      encoding: snappy                 # wal encoding/compression.  options: none, gzip, lz4-64k, lz4-256k, lz4-1M, lz4, snappy, zstd, s2
+    local:
+      path: /tmp/tempo/blocks
+    pool:
+      max_workers: 100                 # worker pool determines the number of parallel requests to the object store backend
+      queue_depth: 10000

--- a/javascript/packages/orchestrator/src/providers/podman/resources/grafana.resource.ts
+++ b/javascript/packages/orchestrator/src/providers/podman/resources/grafana.resource.ts
@@ -1,0 +1,113 @@
+import { getRandomPort, makeDir } from "@zombienet/utils";
+import fs from "fs/promises";
+import path from "path";
+import { Client } from "../../client";
+
+export class GrafanaResource {
+  private readonly dataSourcesPath: string;
+
+  constructor(
+    client: Client,
+    private readonly namespace: string,
+    private readonly prometheusIp: string,
+    private readonly tempoIp: string,
+  ) {
+    this.dataSourcesPath = `${client.tmpDir}/grafana/datasources`;
+  }
+
+  public async generateSpec() {
+    const volumes = await this.generateVolumes();
+    const volumeMounts = this.generateVolumesMounts();
+    const containersPorts = await this.generateContainersPorts();
+    const containers = this.generateContainers(volumeMounts, containersPorts);
+    const podSpec = this.generatePodSpec(containers, volumes);
+
+    return podSpec;
+  }
+
+  private async createVolumeDirectories() {
+    await makeDir(this.dataSourcesPath, true);
+  }
+
+  private async generateGrafanaConfig() {
+    const templateConfigPath = path.resolve(__dirname, "./configs/grafana.yml");
+    const grafanaConfigBuffer = await fs.readFile(templateConfigPath);
+
+    let grafanaConfig = grafanaConfigBuffer.toString("utf8");
+    grafanaConfig = grafanaConfig
+      .replace("{{PROMETHEUS_IP}}", this.prometheusIp)
+      .replace("{{TEMPO_IP}}", this.tempoIp);
+
+    await fs.writeFile(`${this.dataSourcesPath}/prometheus.yml`, grafanaConfig);
+  }
+
+  private async generateVolumes() {
+    await this.createVolumeDirectories();
+    await this.generateGrafanaConfig();
+
+    const dataSourcesVolume = {
+      name: "datasources-cfg",
+      hostPath: { type: "Directory", path: this.dataSourcesPath },
+    };
+
+    return [dataSourcesVolume];
+  }
+
+  private generateVolumesMounts() {
+    const dataSourcesVolumeMount = {
+      name: "datasources-cfg",
+      mountPath: "/etc/grafana/provisioning/datasources",
+      readOnly: false,
+    };
+
+    return [dataSourcesVolumeMount];
+  }
+
+  private async generateContainersPorts() {
+    const grafanaWebPort = {
+      containerPort: 3000,
+      name: "grafana_web",
+      hostPort: await getRandomPort(),
+    };
+
+    return [grafanaWebPort];
+  }
+
+  private generateContainers(volumeMounts: any, ports: any) {
+    const grafanaContainerSpec = {
+      image: "docker.io/grafana/grafana",
+      name: "grafana",
+      imagePullPolicy: "Always",
+      ports,
+      volumeMounts,
+    };
+
+    return [grafanaContainerSpec];
+  }
+
+  private generatePodSpec(containers: any[], volumes: any[]) {
+    const grafanaPodSpec = {
+      apiVersion: "v1",
+      kind: "Pod",
+      metadata: {
+        name: "grafana_pod",
+        namespace: this.namespace,
+        labels: {
+          "app.kubernetes.io/name": this.namespace,
+          "app.kubernetes.io/instance": "grafana",
+          "zombie-role": "grafana",
+          app: "zombienet",
+          "zombie-ns": this.namespace,
+        },
+      },
+      spec: {
+        hostname: "grafana",
+        restartPolicy: "OnFailure",
+        volumes,
+        containers,
+      },
+    };
+
+    return grafanaPodSpec;
+  }
+}

--- a/javascript/packages/orchestrator/src/providers/podman/resources/index.ts
+++ b/javascript/packages/orchestrator/src/providers/podman/resources/index.ts
@@ -1,4 +1,5 @@
 export { GrafanaResource } from "./grafana.resource";
 export { IntrospectorResource } from "./introspector.resource";
+export { NodeResource } from "./node.resource";
 export { PrometheusResource } from "./prometheus.resource";
 export { TempoResource } from "./tempo.resource";

--- a/javascript/packages/orchestrator/src/providers/podman/resources/index.ts
+++ b/javascript/packages/orchestrator/src/providers/podman/resources/index.ts
@@ -1,1 +1,2 @@
+export { GrafanaResource } from "./grafana.resource";
 export { PrometheusResource } from "./prometheus.resource";

--- a/javascript/packages/orchestrator/src/providers/podman/resources/index.ts
+++ b/javascript/packages/orchestrator/src/providers/podman/resources/index.ts
@@ -1,3 +1,4 @@
+export { BootNodeResource } from "./boot-node.resource";
 export { GrafanaResource } from "./grafana.resource";
 export { IntrospectorResource } from "./introspector.resource";
 export { NodeResource } from "./node.resource";

--- a/javascript/packages/orchestrator/src/providers/podman/resources/index.ts
+++ b/javascript/packages/orchestrator/src/providers/podman/resources/index.ts
@@ -1,3 +1,4 @@
 export { GrafanaResource } from "./grafana.resource";
+export { IntrospectorResource } from "./introspector.resource";
 export { PrometheusResource } from "./prometheus.resource";
 export { TempoResource } from "./tempo.resource";

--- a/javascript/packages/orchestrator/src/providers/podman/resources/index.ts
+++ b/javascript/packages/orchestrator/src/providers/podman/resources/index.ts
@@ -1,2 +1,3 @@
 export { GrafanaResource } from "./grafana.resource";
 export { PrometheusResource } from "./prometheus.resource";
+export { TempoResource } from "./tempo.resource";

--- a/javascript/packages/orchestrator/src/providers/podman/resources/index.ts
+++ b/javascript/packages/orchestrator/src/providers/podman/resources/index.ts
@@ -1,0 +1,1 @@
+export { PrometheusResource } from "./prometheus.resource";

--- a/javascript/packages/orchestrator/src/providers/podman/resources/introspector.resource.ts
+++ b/javascript/packages/orchestrator/src/providers/podman/resources/introspector.resource.ts
@@ -1,0 +1,65 @@
+import { getRandomPort } from "@zombienet/utils";
+import { INTROSPECTOR_POD_NAME } from "../../../constants";
+
+export class IntrospectorResource {
+  constructor(
+    private readonly namespace: string,
+    private readonly wsUri: string,
+  ) {}
+
+  public async generateSpec() {
+    const containerPorts = await this.generateContainersPorts();
+    const containers = this.generateContainers(containerPorts);
+    const podSpec = this.generatePodSpec(containers);
+
+    return podSpec;
+  }
+
+  private async generateContainersPorts() {
+    const prometheusPort = {
+      containerPort: 65432,
+      name: "prometheus",
+      hostPort: await getRandomPort(),
+    };
+
+    return [prometheusPort];
+  }
+
+  private generateContainers(ports: any) {
+    const introspectorContainerSpec = {
+      image: "docker.io/paritytech/polkadot-introspector:latest",
+      name: INTROSPECTOR_POD_NAME,
+      args: ["block-time-monitor", `--ws=${this.wsUri}`, "prometheus"],
+      imagePullPolicy: "Always",
+      ports,
+      volumeMounts: [],
+    };
+
+    return [introspectorContainerSpec];
+  }
+
+  private generatePodSpec(containers: any[]) {
+    const podSpec = {
+      apiVersion: "v1",
+      kind: "Pod",
+      metadata: {
+        name: `${INTROSPECTOR_POD_NAME}_pod`,
+        namespace: this.namespace,
+        labels: {
+          "app.kubernetes.io/name": this.namespace,
+          "app.kubernetes.io/instance": INTROSPECTOR_POD_NAME,
+          "zombie-role": INTROSPECTOR_POD_NAME,
+          app: "zombienet",
+          "zombie-ns": this.namespace,
+        },
+      },
+      spec: {
+        hostname: INTROSPECTOR_POD_NAME,
+        containers: containers,
+        restartPolicy: "OnFailure",
+      },
+    };
+
+    return podSpec;
+  }
+}

--- a/javascript/packages/orchestrator/src/providers/podman/resources/node.resource.ts
+++ b/javascript/packages/orchestrator/src/providers/podman/resources/node.resource.ts
@@ -1,0 +1,177 @@
+import { getRandomPort, makeDir } from "@zombienet/utils";
+import { genCmd, genCumulusCollatorCmd } from "../../../cmdGenerator";
+import {
+  P2P_PORT,
+  PROMETHEUS_PORT,
+  RPC_HTTP_PORT,
+  RPC_WS_PORT,
+} from "../../../constants";
+import { Node } from "../../../types";
+import { Client } from "../../client";
+
+export class NodeResource {
+  private readonly configPath: string;
+  private readonly dataPath: string;
+  private readonly relayDataPath: string;
+
+  constructor(
+    client: Client,
+    protected readonly namespace: string,
+    protected readonly nodeSetupConfig: Node,
+  ) {
+    const nodeName = nodeSetupConfig.name;
+    this.configPath = `${client.tmpDir}/${nodeName}/cfg`;
+    this.dataPath = `${client.tmpDir}/${nodeName}/data`;
+    this.relayDataPath = `${client.tmpDir}/${nodeName}/relay-data`;
+  }
+
+  public async generateSpec() {
+    const volumes = await this.generateVolumes();
+    const volumeMounts = this.generateVolumesMounts();
+    const containersPorts = await this.generateContainersPorts();
+    const containers = await this.generateContainers(
+      volumeMounts,
+      containersPorts,
+    );
+    const podManifest = this.generatePodSpec(containers, volumes);
+
+    return podManifest;
+  }
+
+  private async createVolumeDirectories() {
+    await makeDir(this.configPath, true);
+    await makeDir(this.dataPath, true);
+    await makeDir(this.relayDataPath, true);
+  }
+
+  private async generateVolumes() {
+    await this.createVolumeDirectories();
+
+    const configVolume = {
+      name: "tmp-cfg",
+      hostPath: { type: "Directory", path: this.configPath },
+    };
+    const dataVolume = {
+      name: "tmp-data",
+      hostPath: { type: "Directory", path: this.dataPath },
+    };
+    const relayDataVolume = {
+      name: "tmp-relay-data",
+      hostPath: { type: "Directory", path: this.relayDataPath },
+    };
+
+    return [configVolume, dataVolume, relayDataVolume];
+  }
+
+  private generateVolumesMounts() {
+    const configVolumeMount = {
+      name: "tmp-cfg",
+      mountPath: "/cfg:U",
+      readOnly: false,
+    };
+    const dataVolumeMount = {
+      name: "tmp-data",
+      mountPath: "/data:U",
+      readOnly: false,
+    };
+    const relayDataVolumeMount = {
+      name: "tmp-relay-data",
+      mountPath: "/relay-data:U",
+      readOnly: false,
+    };
+
+    return [configVolumeMount, dataVolumeMount, relayDataVolumeMount];
+  }
+
+  private async portFromNodeSetupConfigOrDefault(
+    portProperty: keyof NonNullable<Node["externalPorts"]>,
+  ) {
+    const { externalPorts } = this.nodeSetupConfig;
+
+    if (externalPorts && portProperty in externalPorts) {
+      return externalPorts[portProperty];
+    }
+
+    return getRandomPort();
+  }
+
+  private async generateContainersPorts() {
+    const prometheusPort = {
+      containerPort: PROMETHEUS_PORT,
+      name: "prometheus",
+      hostPort: await this.portFromNodeSetupConfigOrDefault("prometheusPort"),
+    };
+    const rpcHttpPort = {
+      containerPort: RPC_HTTP_PORT,
+      name: "rpc",
+      hostPort: await this.portFromNodeSetupConfigOrDefault("rpcPort"),
+    };
+    const rpcWsPort = {
+      containerPort: RPC_WS_PORT,
+      name: "rpc-ws",
+      hostPort: await this.portFromNodeSetupConfigOrDefault("wsPort"),
+    };
+    const p2pPort = {
+      containerPort: P2P_PORT,
+      name: "p2p",
+      hostPort: await this.portFromNodeSetupConfigOrDefault("p2pPort"),
+    };
+
+    return [prometheusPort, rpcHttpPort, rpcWsPort, p2pPort];
+  }
+
+  private generateContainerCommand() {
+    if (this.nodeSetupConfig.zombieRole === "cumulus-collator") {
+      return genCumulusCollatorCmd(this.nodeSetupConfig);
+    }
+
+    return genCmd(this.nodeSetupConfig);
+  }
+
+  private async generateContainers(volumeMounts: any, ports: any) {
+    const bootNodeContainerSpec = {
+      image: this.nodeSetupConfig.image,
+      name: this.nodeSetupConfig.name,
+      imagePullPolicy: "Always",
+      env: this.nodeSetupConfig.env,
+      volumeMounts,
+      ports,
+      command: await this.generateContainerCommand(),
+    };
+
+    return [bootNodeContainerSpec];
+  }
+
+  protected generatePodSpec(containers: any[], volumes: any[]): any {
+    const { name, validator } = this.nodeSetupConfig;
+
+    const bootNodePodSpec = {
+      apiVersion: "v1",
+      kind: "Pod",
+      metadata: {
+        name: `${name}_pod`,
+        namespace: this.namespace,
+        labels: {
+          "zombie-role": validator ? "authority" : "full-node",
+          app: "zombienet",
+          "zombie-ns": this.namespace,
+          "app.kubernetes.io/name": this.namespace,
+          "app.kubernetes.io/instance": name,
+        },
+        annotations: {
+          "prometheus.io/scrape": "true",
+          "prometheus.io/port": `${PROMETHEUS_PORT}`,
+        },
+      },
+      spec: {
+        hostname: name,
+        initContainers: [],
+        restartPolicy: "OnFailure",
+        volumes,
+        containers,
+      },
+    };
+
+    return bootNodePodSpec;
+  }
+}

--- a/javascript/packages/orchestrator/src/providers/podman/resources/prometheus.resource.ts
+++ b/javascript/packages/orchestrator/src/providers/podman/resources/prometheus.resource.ts
@@ -1,0 +1,116 @@
+import { getRandomPort, makeDir } from "@zombienet/utils";
+import fs from "fs/promises";
+import path from "path";
+import { Client } from "../../client";
+
+export class PrometheusResource {
+  private readonly configPath: string;
+  private readonly dataPath: string;
+
+  constructor(client: Client, private readonly namespace: string) {
+    this.configPath = `${client.tmpDir}/prometheus/etc`;
+    this.dataPath = `${client.tmpDir}/prometheus/data`;
+  }
+
+  public async generateSpec() {
+    const volumes = await this.generateVolumes();
+    const volumeMounts = this.generateVolumesMounts();
+    const containersPorts = await this.generateContainersPorts();
+    const containers = this.generateContainers(volumeMounts, containersPorts);
+    const podSpec = this.generatePodSpec(containers, volumes);
+
+    return podSpec;
+  }
+
+  private async createVolumeDirectories() {
+    await makeDir(this.configPath, true);
+    await makeDir(this.dataPath, true);
+  }
+
+  private async generatePrometheusConfig() {
+    const templateConfigPath = path.resolve(
+      __dirname,
+      "./configs/prometheus.yml",
+    );
+    await fs.copyFile(templateConfigPath, `${this.configPath}/prometheus.yml`);
+  }
+
+  private async generateVolumes() {
+    await this.createVolumeDirectories();
+    await this.generatePrometheusConfig();
+
+    const configVolume = {
+      name: "prom-cfg",
+      hostPath: { type: "Directory", path: this.configPath },
+    };
+    const dataVolume = {
+      name: "prom-data",
+      hostPath: { type: "Directory", path: this.dataPath },
+    };
+
+    return [configVolume, dataVolume];
+  }
+
+  private generateVolumesMounts() {
+    const configVolumeMount = {
+      name: "prom-cfg",
+      mountPath: "/etc/prometheus",
+      readOnly: false,
+    };
+    const dataVolumeMount = {
+      name: "prom-data",
+      mountPath: "/data",
+      readOnly: false,
+    };
+
+    return [configVolumeMount, dataVolumeMount];
+  }
+
+  private async generateContainersPorts() {
+    const prometheusPort = {
+      containerPort: 9090,
+      name: "prometheus_endpoint",
+      hostPort: await getRandomPort(),
+    };
+
+    return [prometheusPort];
+  }
+
+  private generateContainers(volumeMounts: any, ports: any) {
+    const prometheusContainerSpec = {
+      image: "docker.io/prom/prometheus",
+      name: "prometheus",
+      imagePullPolicy: "Always",
+      ports,
+      volumeMounts,
+    };
+
+    return [prometheusContainerSpec];
+  }
+
+  private generatePodSpec(containers: any[], volumes: any[]) {
+    const podSpec = {
+      apiVersion: "v1",
+      kind: "Pod",
+      metadata: {
+        name: "prometheus_pod",
+        namespace: this.namespace,
+        labels: {
+          "app.kubernetes.io/name": this.namespace,
+          "app.kubernetes.io/instance": "prometheus",
+          "zombie-role": "prometheus",
+          app: "zombienet",
+          "zombie-ns": this.namespace,
+        },
+      },
+      spec: {
+        hostname: "prometheus",
+        restartPolicy: "OnFailure",
+        volumes,
+        containers,
+      },
+    };
+
+    return podSpec;
+  }
+}

--- a/javascript/packages/orchestrator/src/providers/podman/resources/tempo.resource.ts
+++ b/javascript/packages/orchestrator/src/providers/podman/resources/tempo.resource.ts
@@ -1,0 +1,140 @@
+import { getRandomPort, makeDir } from "@zombienet/utils";
+import fs from "fs/promises";
+import path from "path";
+import { Client } from "../../client";
+
+export class TempoResource {
+  private readonly configPath: string;
+  private readonly dataPath: string;
+
+  constructor(client: Client, private readonly namespace: string) {
+    this.configPath = `${client.tmpDir}/tempo/etc`;
+    this.dataPath = `${client.tmpDir}/tempo/data`;
+  }
+
+  public async generateSpec() {
+    const volumes = await this.generateVolumes();
+    const volumeMounts = this.generateVolumesMounts();
+    const containersPorts = await this.generateContainersPorts();
+    const containers = this.generateContainers(volumeMounts, containersPorts);
+    const podSpec = this.generatePodSpec(containers, volumes);
+
+    return podSpec;
+  }
+
+  private async createVolumeDirectories() {
+    await makeDir(this.configPath, true);
+    await makeDir(this.dataPath, true);
+  }
+
+  private async generateTempoConfig() {
+    const templateConfigPath = path.resolve(__dirname, `./configs/tempo.yaml`);
+    await fs.copyFile(templateConfigPath, `${this.configPath}/tempo.yaml`);
+  }
+
+  private async generateVolumes() {
+    await this.createVolumeDirectories();
+    await this.generateTempoConfig();
+
+    const configVolume = {
+      name: "tempo-cfg",
+      hostPath: { type: "Directory", path: this.configPath },
+    };
+    const dataVolume = {
+      name: "tempo-data",
+      hostPath: { type: "Directory", path: this.dataPath },
+    };
+
+    return [configVolume, dataVolume];
+  }
+
+  private generateVolumesMounts() {
+    const configVolumeMount = {
+      name: "tempo-cfg",
+      mountPath: "/etc/tempo",
+      readOnly: false,
+    };
+    const dataVolumeMount = {
+      name: "tempo-data",
+      mountPath: "/data",
+      readOnly: false,
+    };
+
+    return [configVolumeMount, dataVolumeMount];
+  }
+
+  private async generateContainersPorts() {
+    const tempoPort = {
+      containerPort: 3100,
+      name: "tempo",
+      hostPort: await getRandomPort(),
+    };
+    const jaegerIngestPort = {
+      containerPort: 14268,
+      name: "jaeger_ingest",
+      hostPort: await getRandomPort(),
+    };
+    const otlpGrpcPort = {
+      containerPort: 4317,
+      name: "otlp_grpc",
+      hostPort: await getRandomPort(),
+    };
+    const otlpHttpPort = {
+      containerPort: 4318,
+      name: "otlp_http",
+      hostPort: await getRandomPort(),
+    };
+    const zipkinPort = {
+      containerPort: 9411,
+      name: "zipkin",
+      hostPort: await getRandomPort(),
+    };
+
+    return [
+      tempoPort,
+      jaegerIngestPort,
+      otlpGrpcPort,
+      otlpHttpPort,
+      zipkinPort,
+    ];
+  }
+
+  private generateContainers(volumeMounts: any, ports: any) {
+    const tempoContainerSpec = {
+      image: "docker.io/grafana/tempo:latest",
+      name: "tempo",
+      args: ["-config.file=/etc/tempo/tempo.yaml"],
+      imagePullPolicy: "Always",
+      ports,
+      volumeMounts,
+    };
+
+    return [tempoContainerSpec];
+  }
+
+  private generatePodSpec(containers: any[], volumes: any[]) {
+    const podSpec = {
+      apiVersion: "v1",
+      kind: "Pod",
+      metadata: {
+        name: "tempo_pod",
+        namespace: this.namespace,
+        labels: {
+          "app.kubernetes.io/name": this.namespace,
+          "app.kubernetes.io/instance": "tempo",
+          "zombie-role": "tempo",
+          app: "zombienet",
+          "zombie-ns": this.namespace,
+        },
+      },
+      spec: {
+        hostname: "tempo",
+        restartPolicy: "OnFailure",
+        volumes,
+        containers,
+      },
+    };
+
+    return podSpec;
+  }
+}


### PR DESCRIPTION
Preparation work to support podman v4 and refactoring the podman provider to make it cleaner.

The different resources have been split on individual file exposing only one public method as an API to generate the specification from the parameter given in the constructor, hence, respecting the [Single Responsibility Principle](https://en.wikipedia.org/wiki/Single-responsibility_principle).

The issues with the v4 will be the naming of pod which are not suffixed with _pod anymore if the pod has the same name as the container inside it.

The short term objective is to make the code cleaner and the medium term one is to be able to inverse dependency on filesystem/api call/shell ([Dependency inversion principle](https://en.wikipedia.org/wiki/Dependency_inversion_principle)) call to make it easier to unit test providers in an isolated fashion, starting with the podman provider.

Open to suggestions.