### PR TITLE
add ci vars to easily match ns to jobs in pipelines

### DIFF
--- a/javascript/packages/orchestrator/src/providers/k8s/kubeClient.ts
+++ b/javascript/packages/orchestrator/src/providers/k8s/kubeClient.ts
@@ -87,6 +87,8 @@ export class KubeClient extends Client {
       kind: "Namespace",
       metadata: {
         name: this.namespace,
+        jobId: process.env.CI_JOB_ID || "",
+        projectName: process.env.CI_PROJECT_NAME || ""
       },
     };
 

--- a/javascript/packages/orchestrator/src/providers/k8s/kubeClient.ts
+++ b/javascript/packages/orchestrator/src/providers/k8s/kubeClient.ts
@@ -88,7 +88,7 @@ export class KubeClient extends Client {
       metadata: {
         name: this.namespace,
         jobId: process.env.CI_JOB_ID || "",
-        projectName: process.env.CI_PROJECT_NAME || ""
+        projectName: process.env.CI_PROJECT_NAME || "",
       },
     };
 

--- a/javascript/packages/orchestrator/src/providers/k8s/kubeClient.ts
+++ b/javascript/packages/orchestrator/src/providers/k8s/kubeClient.ts
@@ -87,8 +87,10 @@ export class KubeClient extends Client {
       kind: "Namespace",
       metadata: {
         name: this.namespace,
-        jobId: process.env.CI_JOB_ID || "",
-        projectName: process.env.CI_PROJECT_NAME || "",
+        labels: {
+          jobId: process.env.CI_JOB_ID || "",
+          projectName: process.env.CI_PROJECT_NAME || "",
+        },
       },
     };
 


### PR DESCRIPTION
We are working on improving the infra observability and this pr will allow us to map `namespaces` to `jobs` in our pipeline.
