### PR TITLE
Update code to support minimatch 9.0.0

### DIFF
--- a/javascript/packages/orchestrator/src/networkNode.ts
+++ b/javascript/packages/orchestrator/src/networkNode.ts
@@ -1,6 +1,6 @@
 import { ApiPromise, WsProvider } from "@polkadot/api";
 import axios from "axios";
-import minimatch from "minimatch";
+import { makeRe } from "minimatch";
 
 import {
   DEFAULT_INDIVIDUAL_TEST_TIMEOUT,
@@ -366,7 +366,7 @@ export class NetworkNode implements NetworkNodeInterface {
   ): Promise<number> {
     try {
       let total_count = 0;
-      const re = isGlob ? minimatch.makeRe(pattern) : new RegExp(pattern, "ig");
+      const re = isGlob ? makeRe(pattern) : new RegExp(pattern, "ig");
       if (!re) throw new Error(`Invalid glob pattern: ${pattern} `);
       const client = getClient();
       const getValue = async (): Promise<number> => {
@@ -416,7 +416,7 @@ export class NetworkNode implements NetworkNodeInterface {
     timeout: number = DEFAULT_INDIVIDUAL_TEST_TIMEOUT,
   ): Promise<boolean> {
     try {
-      const re = isGlob ? minimatch.makeRe(pattern) : new RegExp(pattern, "ig");
+      const re = isGlob ? makeRe(pattern) : new RegExp(pattern, "ig");
       if (!re) throw new Error(`Invalid glob pattern: ${pattern} `);
       const client = getClient();
       let logs = await client.getNodeLogs(this.name, undefined, true);

--- a/javascript/packages/orchestrator/src/test-runner/assertions.ts
+++ b/javascript/packages/orchestrator/src/test-runner/assertions.ts
@@ -2,7 +2,7 @@ import { ApiPromise, Keyring } from "@polkadot/api";
 import { decorators, isValidHttpUrl } from "@zombienet/utils";
 import { assert, expect } from "chai";
 import { JSDOM } from "jsdom";
-import minimatch from "minimatch";
+import { makeRe } from "minimatch";
 import path from "path";
 import { BackchannelMap } from ".";
 import {
@@ -166,7 +166,7 @@ const SystemEvent = ({ node_name, pattern, match_type, timeout }: FnArgs) => {
   return async (network: Network) => {
     const node = network.node(node_name!);
     const api: ApiPromise = await connect(node.wsUri);
-    const re = isGlob ? minimatch.makeRe(pattern!) : new RegExp(pattern!, "ig");
+    const re = isGlob ? makeRe(pattern!) : new RegExp(pattern!, "ig");
     const found = await findPatternInSystemEventSubscription(
       api,
       re as RegExp,


### PR DESCRIPTION
[Next version of minimatch (9.0.0)](https://github.com/isaacs/minimatch/blob/main/changelog.md#90) does not allow default exports anymore; (see failing dependabot PRs:  #912 #913);
Minimatch imports should be updated from default to named ones;