### PR TITLE
Fixes for no leaking resources in k8s

### DIFF
--- a/javascript/packages/orchestrator/src/test-runner/index.ts
+++ b/javascript/packages/orchestrator/src/test-runner/index.ts
@@ -138,33 +138,11 @@ export async function run(
           console.log(
             `\n\n\t${decorators.red("❌ One or more of your test failed...")}`,
           );
-
-          switch (network.client.providerName) {
-            case "podman":
-            case "native":
-              console.log(`\n\t ${decorators.green("Deleting network")}`);
-              await network.stop();
-              break;
-            case "kubernetes":
-              if (inCI) {
-                // keep pods running for 30 mins.
-                console.log(
-                  `\n\t${decorators.red(
-                    "One or more test failed, we will keep the namespace up for 30 more minutes",
-                  )}`,
-                );
-                await network.upsertCronJob(30);
-              } else {
-                console.log(`\n\t ${decorators.green("Deleting network")}`);
-                await network.stop();
-              }
-              break;
-          }
-        } else {
-          // All test passed, just remove the network
-          console.log(`\n\t ${decorators.green("Deleting network")}`);
-          await network.stop();
         }
+
+        // All test passed, just remove the network
+        console.log(`\n\t ${decorators.green("Deleting network")}`);
+        await network.stop();
 
         // show logs
         console.log(

--- a/javascript/packages/orchestrator/static-configs/job-svc-account.yaml
+++ b/javascript/packages/orchestrator/static-configs/job-svc-account.yaml
@@ -25,7 +25,7 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: RoleBinding
 metadata:
   name: delete-podmonitor-to-sa
 subjects:
@@ -33,6 +33,6 @@ subjects:
     name: zombie-internal-kubectl
     namespace: "{{namespace}}"
 roleRef:
-  kind: ClusterRole
+  kind: Role
   name: delete-podmonitors
   apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
- This fix the permissions to allow the CronJob to delete the `ns` (@emamihe)
- Remove the logic to keep the network up for 30mins on `ci`, since we are exporting the logs to the pipeline now and external users can check them there.

Thanks!