### PR TITLE
fix race condition

### DIFF
--- a/javascript/packages/orchestrator/src/paras.ts
+++ b/javascript/packages/orchestrator/src/paras.ts
@@ -59,7 +59,9 @@ export async function generateParachainFiles(
   );
 
   let chainSpecFullPath;
-  const chainName = `${parachain.chain ? parachain.chain + "-" : ""}${parachain.name}-${relayChainName}`;
+  const chainName = `${parachain.chain ? parachain.chain + "-" : ""}${
+    parachain.name
+  }-${relayChainName}`;
   const chainSpecFileName = `${chainName}.json`;
 
   const chainSpecFullPathPlain = `${tmpDir}/${chainName}-plain.json`;

--- a/javascript/packages/orchestrator/src/paras.ts
+++ b/javascript/packages/orchestrator/src/paras.ts
@@ -47,6 +47,8 @@ export async function generateParachainFiles(
     chainSpecFns.addCollatorSelection,
     chainSpecFns.writeChainSpec,
   ]);
+  const GENESIS_STATE_FILENAME_WITH_ID = `${GENESIS_STATE_FILENAME}-${parachain.id}`;
+  const GENESIS_WASM_FILENAME_WITH_ID = `${GENESIS_WASM_FILENAME}-${parachain.id}`;
 
   const stateLocalFilePath = `${parachainFilesPath}/${GENESIS_STATE_FILENAME}`;
   const wasmLocalFilePath = `${parachainFilesPath}/${GENESIS_WASM_FILENAME}`;
@@ -57,13 +59,10 @@ export async function generateParachainFiles(
   );
 
   let chainSpecFullPath;
-  const chainSpecFileName = `${parachain.chain ? parachain.chain + "-" : ""}${
-    parachain.name
-  }-${relayChainName}.json`;
+  const chainName = `${parachain.chain ? parachain.chain + "-" : ""}${parachain.name}-${relayChainName}`;
+  const chainSpecFileName = `${chainName}.json`;
 
-  const chainSpecFullPathPlain = `${tmpDir}/${
-    parachain.chain ? parachain.chain + "-" : ""
-  }${parachain.name}-${relayChainName}-plain.json`;
+  const chainSpecFullPathPlain = `${tmpDir}/${chainName}-plain.json`;
 
   if (parachain.cumulusBased) {
     // need to create the parachain spec
@@ -89,7 +88,7 @@ export async function generateParachainFiles(
           } --disable-default-bootnode`,
           defaultImage: parachain.collators[0].image,
         },
-        relayChainName,
+        chainName,
         chainSpecFullPathPlain,
       );
     }
@@ -222,7 +221,7 @@ export async function generateParachainFiles(
           ` --chain ${chainSpecPathInNode} > `,
         );
       }
-      commands.push(genesisStateGenerator);
+      commands.push(`${genesisStateGenerator}-${parachain.id}`);
     }
     if (parachain.genesisWasmGenerator) {
       let genesisWasmGenerator = parachain.genesisWasmGenerator.replace(
@@ -241,7 +240,7 @@ export async function generateParachainFiles(
           ` --chain ${chainSpecPathInNode} > `,
         );
       }
-      commands.push(genesisWasmGenerator);
+      commands.push(`${genesisWasmGenerator}-${parachain.id}`);
     }
 
     // Native provider doesn't need to wait
@@ -278,7 +277,7 @@ export async function generateParachainFiles(
     if (parachain.genesisStateGenerator) {
       await client.copyFileFromPod(
         podDef.metadata.name,
-        `${client.remoteDir}/${GENESIS_STATE_FILENAME}`,
+        `${client.remoteDir}/${GENESIS_STATE_FILENAME_WITH_ID}`,
         stateLocalFilePath,
       );
     }
@@ -286,7 +285,7 @@ export async function generateParachainFiles(
     if (parachain.genesisWasmGenerator) {
       await client.copyFileFromPod(
         podDef.metadata.name,
-        `${client.remoteDir}/${GENESIS_WASM_FILENAME}`,
+        `${client.remoteDir}/${GENESIS_WASM_FILENAME_WITH_ID}`,
         wasmLocalFilePath,
       );
     }


### PR DESCRIPTION
fix #942

Fix the bug introduced by changing the default concurrency from 1 to 4 (https://github.com/paritytech/zombienet/blob/main/javascript/packages/cli/src/actions/spawn.ts#L41), used for both spawning nodes and build the parachains artifacts. The bug is only affected to `native` provider since we are using the same `filename` and that cause the race condition. In other providers isn't a problem since the pod fs is isolated.

Thanks!