### PR TITLE
feat(orchestrator): switch to concurrency 1 when network definiton us…

### DIFF
--- a/javascript/packages/cli/src/cli.ts
+++ b/javascript/packages/cli/src/cli.ts
@@ -39,12 +39,12 @@ process.on("uncaughtException", async (err) => {
 // Ensure that we know about any exception thrown in a promise that we
 // accidentally don't have a 'catch' for.
 // http://www.hacksrus.net/blog/2015/08/a-solution-to-swallowed-exceptions-in-es6s-promises/
-process.on("unhandledRejection", async (err: Error) => {
+process.on("unhandledRejection", async (err) => {
   await handleTermination();
   debug(err);
   console.log(
     `\n${decorators.red("UnhandledRejection: ")} \t ${decorators.bright(
-      JSON.stringify(err),
+      err,
     )}\n`,
   );
   process.exit(1001);

--- a/javascript/packages/cli/src/cli.ts
+++ b/javascript/packages/cli/src/cli.ts
@@ -39,12 +39,12 @@ process.on("uncaughtException", async (err) => {
 // Ensure that we know about any exception thrown in a promise that we
 // accidentally don't have a 'catch' for.
 // http://www.hacksrus.net/blog/2015/08/a-solution-to-swallowed-exceptions-in-es6s-promises/
-process.on("unhandledRejection", async (err) => {
+process.on("unhandledRejection", async (err: Error) => {
   await handleTermination();
   debug(err);
   console.log(
     `\n${decorators.red("UnhandledRejection: ")} \t ${decorators.bright(
-      err,
+      JSON.stringify(err),
     )}\n`,
   );
   process.exit(1001);

--- a/javascript/packages/orchestrator/src/constants.ts
+++ b/javascript/packages/orchestrator/src/constants.ts
@@ -103,6 +103,8 @@ const ARGS_TO_REMOVE: { [key: string]: number } = {
   "base-path": 2,
 };
 
+const TOKEN_PLACEHOLDER = /{{ZOMBIE:(.*?):(.*?)}}/gi;
+
 export {
   REGULAR_BIN_PATH,
   PROMETHEUS_PORT,
@@ -158,4 +160,5 @@ export {
   ARGS_TO_REMOVE,
   UNDYING_COLLATOR_BIN,
   K8S_WAIT_UNTIL_SCRIPT_SUFIX,
+  TOKEN_PLACEHOLDER,
 };

--- a/javascript/packages/orchestrator/src/network-helpers/verifier.ts
+++ b/javascript/packages/orchestrator/src/network-helpers/verifier.ts
@@ -6,6 +6,19 @@ import { decorate } from "../paras-decorators";
 
 const debug = require("debug")("zombie::helper::verifier");
 
+
+export const nodeChecker = async (node: NetworkNode) => {
+  const metricToQuery = node.para
+    ? decorate(node.para, [getProcessStartTimeKey])[0]()
+    : getProcessStartTimeKey();
+  debug(
+    `\t checking node: ${node.name} with prometheusUri: ${node.prometheusUri} - key: ${metricToQuery}`,
+  );
+  const ready = await node.getMetric(metricToQuery, "isAtLeast", 1, 60 * 5);
+  debug(`\t ${node.name} ready ${ready}`);
+  return ready;
+};
+
 // Verify that the nodes of the supplied network are up/running.
 // To verify that the node is running we use the startProcessTime from
 // prometheus server exposed in each node.
@@ -18,17 +31,6 @@ const debug = require("debug")("zombie::helper::verifier");
 // at the moment. This value should work ok but we can also optimize later.
 export async function verifyNodes(network: Network) {
   // wait until all the node's are up
-  const nodeChecker = async (node: NetworkNode) => {
-    const metricToQuery = node.para
-      ? decorate(node.para, [getProcessStartTimeKey])[0]()
-      : getProcessStartTimeKey();
-    debug(
-      `\t checking node: ${node.name} with prometheusUri: ${node.prometheusUri} - key: ${metricToQuery}`,
-    );
-    const ready = await node.getMetric(metricToQuery, "isAtLeast", 1, 60 * 5);
-    debug(`\t ${node.name} ready ${ready}`);
-    return ready;
-  };
   const nodeCheckGenerators = Object.values(network.nodesByName).map(
     (node: NetworkNode) => {
       return () => nodeChecker(node);
@@ -40,3 +42,17 @@ export async function verifyNodes(network: Network) {
     throw new Error("At least one of the nodes fails to start");
   debug("All nodes checked ok");
 }
+
+
+//
+// const nodeChecker = async (node: NetworkNode) => {
+//   const metricToQuery = node.para
+//     ? decorate(node.para, [getProcessStartTimeKey])[0]()
+//     : getProcessStartTimeKey();
+//   debug(
+//     `\t checking node: ${node.name} with prometheusUri: ${node.prometheusUri} - key: ${metricToQuery}`,
+//   );
+//   const ready = await node.getMetric(metricToQuery, "isAtLeast", 1, 60 * 5);
+//   debug(`\t ${node.name} ready ${ready}`);
+//   return ready;
+// };

--- a/javascript/packages/orchestrator/src/network-helpers/verifier.ts
+++ b/javascript/packages/orchestrator/src/network-helpers/verifier.ts
@@ -42,17 +42,3 @@ export async function verifyNodes(network: Network) {
     throw new Error("At least one of the nodes fails to start");
   debug("All nodes checked ok");
 }
-
-
-//
-// const nodeChecker = async (node: NetworkNode) => {
-//   const metricToQuery = node.para
-//     ? decorate(node.para, [getProcessStartTimeKey])[0]()
-//     : getProcessStartTimeKey();
-//   debug(
-//     `\t checking node: ${node.name} with prometheusUri: ${node.prometheusUri} - key: ${metricToQuery}`,
-//   );
-//   const ready = await node.getMetric(metricToQuery, "isAtLeast", 1, 60 * 5);
-//   debug(`\t ${node.name} ready ${ready}`);
-//   return ready;
-// };

--- a/javascript/packages/orchestrator/src/network.ts
+++ b/javascript/packages/orchestrator/src/network.ts
@@ -9,6 +9,7 @@ import {
   BAKCCHANNEL_PORT,
   BAKCCHANNEL_URI_PATTERN,
   DEFAULT_INDIVIDUAL_TEST_TIMEOUT,
+  TOKEN_PLACEHOLDER,
 } from "./constants";
 import { Metrics } from "./metrics";
 import { NetworkNode } from "./networkNode";
@@ -369,7 +370,8 @@ export class Network {
 
   replaceWithNetworInfo(placeholder: string): string {
     return placeholder.replace(
-      /{{ZOMBIE:(.*?):(.*?)}}/gi,
+      ///{{ZOMBIE:(.*?):(.*?)}}/gi,
+      TOKEN_PLACEHOLDER,
       (_substring, nodeName, key: keyof NetworkNode) => {
         const node = this.getNodeByName(nodeName);
         return node[key];

--- a/javascript/packages/orchestrator/src/orchestrator.ts
+++ b/javascript/packages/orchestrator/src/orchestrator.ts
@@ -30,6 +30,7 @@ import {
 import {
   GENESIS_STATE_FILENAME,
   GENESIS_WASM_FILENAME,
+  TOKEN_PLACEHOLDER,
   ZOMBIE_WRAPPER,
 } from "./constants";
 import { registerParachain } from "./jsapi-helpers";
@@ -46,7 +47,7 @@ import {
 
 import { spawnIntrospector } from "./network-helpers/instrospector";
 import { setTracingCollatorConfig } from "./network-helpers/tracing-collator";
-import { verifyNodes } from "./network-helpers/verifier";
+import { verifyNodes, nodeChecker } from "./network-helpers/verifier";
 import { Client } from "./providers/client";
 import { KubeClient } from "./providers/k8s/kubeClient";
 import { spawnNode } from "./spawner";
@@ -88,6 +89,13 @@ export async function start(
     const networkSpec: ComputedNetwork = await generateNetworkSpec(
       launchConfig,
     );
+
+    // IFF there are network references in cmds we need to switch to concurrency 1
+    if(TOKEN_PLACEHOLDER.test(JSON.stringify(networkSpec))) {
+      debug("Network definition use network references, switching concurrency to 1");
+      opts.spawnConcurrency = 1;
+    }
+
     debug(JSON.stringify(networkSpec, null, 4));
 
     const { initClient, setupChainSpec, getChainSpecRaw } = getProvider(
@@ -418,6 +426,8 @@ export async function start(
       if (!parachain.addToGenesis && parachain.registerPara) {
         // register parachain on a running network
         const basePath = `${tmpDir.path}/${parachain.name}`;
+        // ensure node is up.
+        await nodeChecker(network.relay[0]);
         await registerParachain({
           id: parachain.id,
           wasmPath: `${basePath}/${GENESIS_WASM_FILENAME}`,


### PR DESCRIPTION
…e references.

- When network definition use references (e.g `{{'dave'|zombie('wsUri')}}`) we need to switch to single concurrency to prevent race conditions.

Thanks!