### PR TITLE
fix(orchestrator): make genesis overrides first

### DIFF
--- a/javascript/packages/orchestrator/src/chainSpec.ts
+++ b/javascript/packages/orchestrator/src/chainSpec.ts
@@ -674,6 +674,12 @@ export async function customizePlainRelayChain(
       ? "session"
       : "aura";
 
+    // make genesis overrides first.
+    if (networkSpec.relaychain.genesis) {
+      await changeGenesisConfig(specPath, networkSpec.relaychain.genesis);
+    }
+
+
     // Clear all defaults
     clearAuthorities(specPath);
 
@@ -705,10 +711,6 @@ export async function customizePlainRelayChain(
         networkSpec.relaychain.maxNominations,
         validatorKeys,
       );
-    }
-
-    if (networkSpec.relaychain.genesis) {
-      await changeGenesisConfig(specPath, networkSpec.relaychain.genesis);
     }
 
     if (networkSpec.hrmp_channels) {

--- a/javascript/packages/orchestrator/src/paras.ts
+++ b/javascript/packages/orchestrator/src/paras.ts
@@ -108,6 +108,10 @@ export async function generateParachainFiles(
 
       writeChainSpec(chainSpecFullPathPlain, plainData);
 
+      // make genesis overrides first.
+      if (parachain.genesis)
+        await changeGenesisConfig(chainSpecFullPathPlain, parachain.genesis);
+
       // clear auths
       await clearAuthorities(chainSpecFullPathPlain);
 
@@ -136,9 +140,6 @@ export async function generateParachainFiles(
           await addParaCustom(chainSpecFullPathPlain, node);
         }
       }
-
-      if (parachain.genesis)
-        await changeGenesisConfig(chainSpecFullPathPlain, parachain.genesis);
 
       debug("creating chain spec raw");
       // ensure needed file


### PR DESCRIPTION
Since currently we could override some keys changed by zombienet.
