### PR TITLE
fix bootnode def, not use ws-external

### DIFF
--- a/javascript/packages/orchestrator/src/configGenerator.ts
+++ b/javascript/packages/orchestrator/src/configGenerator.ts
@@ -429,11 +429,7 @@ export async function generateBootnodeSpec(
     chain: config.relaychain.chain,
     validator: false,
     invulnerable: false,
-    args: [
-      "--rpc-external",
-      "--listen-addr",
-      "/ip4/0.0.0.0/tcp/30333/ws",
-    ],
+    args: ["--rpc-external", "--listen-addr", "/ip4/0.0.0.0/tcp/30333/ws"],
     env: [],
     bootnodes: [],
     telemetryUrl: "",

--- a/javascript/packages/orchestrator/src/configGenerator.ts
+++ b/javascript/packages/orchestrator/src/configGenerator.ts
@@ -430,7 +430,6 @@ export async function generateBootnodeSpec(
     validator: false,
     invulnerable: false,
     args: [
-      "--ws-external",
       "--rpc-external",
       "--listen-addr",
       "/ip4/0.0.0.0/tcp/30333/ws",


### PR DESCRIPTION
Needed by the substrate cli args breaking change.