### PR TITLE
feat(orchestrator): allow set cli args version

### DIFF
--- a/docs/src/network-definition-spec.md
+++ b/docs/src/network-definition-spec.md
@@ -85,12 +85,11 @@ The network config can be provided both in `json` or `toml` format and each sect
     - `image`: (String) Image to use.
     - `command`: (String, default `polkadot-parachain`) Command to run.
     - `args`: (Array of strings) An array of arguments to use as default to pass to the `command`.
-    - `substrate_cli_args_version`: (0|1) By default zombienet will evaluate your binary and set the correct version, but that produce an small overhead that could be skipped if you set directly with this key.
+    - `packages/orchestrator/src/providers/k8s/index.ts`: (0|1) By default zombienet will evaluate your binary and set the correct version, but that produce an small overhead that could be skipped if you set directly with this key.
     - `command_with_args`: (String) Overrides `command` and `args`.
     - `env`: Array of env vars Object to set in the container.
       - name: (String) name of the `env` var.
       - value: (String| number) Value of the env var.
-
 
   - `collator_groups`:
     - `*name`: (String) Name of the collator.

--- a/docs/src/network-definition-spec.md
+++ b/docs/src/network-definition-spec.md
@@ -28,6 +28,7 @@ The network config can be provided both in `json` or `toml` format and each sect
 - `chain_spec_path`: (String) Path to the chain spec file, **NOTE** should be the `plain` version to allow customizations.
 - `chain_spec_command`: (String) Command to generate the chain spec, **NOTE** can't be used in combination with `chain_spec_path`.
 - `default_args`: (Array of strings) An array of arguments to use as default to pass to the `command`.
+- `default_substrate_cli_args_version`: (0|1) Allow to set the substrate cli args version (see: https://github.com/paritytech/substrate/pull/13384). By default zombienet will evaluate your binary and set the correct version, but that produce an small overhead that could be skipped if you set directly with this key.
 - `default_overrides`: (Array of objects) An array of overrides to upload to the nodes, objects with:
   - `local_path`: string;
   - `remote_name`: string;
@@ -40,6 +41,7 @@ The network config can be provided both in `json` or `toml` format and each sect
   - `command`: (String) Override default command.
   - `command_with_args`: (String) Override default command and args.
   - `args`: (Array of strings) Arguments to be passed to the `command`.
+  - `substrate_cli_args_version`: (0|1) By default zombienet will evaluate your binary and set the correct version, but that produce an small overhead that could be skipped if you set directly with this key.
   - `validator`: (Boolean, default true) Pass the `--validator` flag to the `command`.
   - `invulnerable`: (Boolean, default false) If true, the node will be added to `invulnerables` in the chain spec.
   - `balance`: (number, default 2000000000000) Balance to set in `balances` for node's account.
@@ -64,6 +66,7 @@ The network config can be provided both in `json` or `toml` format and each sect
     - value: (String| number) Value of the env var.
   - `overrides`: Array of `overrides` definitions.
   - `resources`: (Object) **Only** available in `kubernetes`, represent the resources `limits`/`reservations` needed by the node.
+  - `substrate_cli_args_version`: (0|1) By default zombienet will evaluate your binary and set the correct version, but that produce an small overhead that could be skipped if you set directly with this key.
 
 ## `parachains`
 
@@ -82,10 +85,12 @@ The network config can be provided both in `json` or `toml` format and each sect
     - `image`: (String) Image to use.
     - `command`: (String, default `polkadot-parachain`) Command to run.
     - `args`: (Array of strings) An array of arguments to use as default to pass to the `command`.
+    - `substrate_cli_args_version`: (0|1) By default zombienet will evaluate your binary and set the correct version, but that produce an small overhead that could be skipped if you set directly with this key.
     - `command_with_args`: (String) Overrides `command` and `args`.
     - `env`: Array of env vars Object to set in the container.
       - name: (String) name of the `env` var.
       - value: (String| number) Value of the env var.
+
 
   - `collator_groups`:
     - `*name`: (String) Name of the collator.
@@ -97,6 +102,7 @@ The network config can be provided both in `json` or `toml` format and each sect
     - `env`: Array of env vars Object to set in the container.
       - name: (String) name of the `env` var.
       - value: (String| number) Value of the env var.
+      - `substrate_cli_args_version`: (0|1) By default zombienet will evaluate your binary and set the correct version, but that produce an small overhead that could be skipped if you set directly with this key.
 
   - `onboard_as_parachain`: (Boolean, default true) flag to specify whether the para should be onboarded as a parachain or stay a parathread
   - `register_para`: (Boolean, default true) flag to specify whether the para should be registered. The `add_to_genesis` flag **must** be set to false for this flag to have any effect.

--- a/javascript/packages/orchestrator/src/configGenerator.ts
+++ b/javascript/packages/orchestrator/src/configGenerator.ts
@@ -206,6 +206,9 @@ export async function generateNetworkSpec(
         resources:
           nodeGroup.resources || networkSpec.relaychain.defaultResources,
         db_snapshot: nodeGroup.db_snapshot,
+        substrate_cli_args_version:
+          nodeGroup.substrate_cli_args_version ||
+          networkSpec.relaychain.default_substrate_cli_args_version,
       };
       const nodeSetup = await getNodeFromConfig(
         networkSpec,
@@ -281,6 +284,11 @@ export async function generateNetworkSpec(
               collatorGroup.resources ||
               networkSpec.relaychain.defaultResources,
           };
+
+          if (collatorGroup.substrate_cli_args_version)
+            node.substrate_cli_args_version =
+              collatorGroup.substrate_cli_args_version;
+
           collators.push(
             await getCollatorNodeFromConfig(
               networkSpec,
@@ -620,6 +628,13 @@ async function getNodeFromConfig(
     : networkSpec.relaychain.defaultDbSnapshot || null;
 
   if (dbSnapshot) nodeSetup.dbSnapshot = dbSnapshot;
+  if (
+    node.substrate_cli_args_version ||
+    networkSpec.default_substrate_cli_args_version
+  )
+    nodeSetup.substrateCliArgsVersion =
+      node.substrate_cli_args_version ||
+      networkSpec.default_substrate_cli_args_version;
   return nodeSetup;
 }
 

--- a/javascript/packages/orchestrator/src/orchestrator.ts
+++ b/javascript/packages/orchestrator/src/orchestrator.ts
@@ -51,6 +51,7 @@ import { nodeChecker, verifyNodes } from "./network-helpers/verifier";
 import { Client } from "./providers/client";
 import { KubeClient } from "./providers/k8s/kubeClient";
 import { spawnNode } from "./spawner";
+import { setSubstrateCliArgsVersion } from "./substrateCliArgsHelper";
 
 const debug = require("debug")("zombie");
 
@@ -100,12 +101,9 @@ export async function start(
 
     debug(JSON.stringify(networkSpec, null, 4));
 
-    const {
-      initClient,
-      setupChainSpec,
-      getChainSpecRaw,
-      setSubstrateCliArdsVersion,
-    } = getProvider(networkSpec.settings.provider);
+    const { initClient, setupChainSpec, getChainSpecRaw } = getProvider(
+      networkSpec.settings.provider,
+    );
 
     // global timeout to spin the network
     const timeoutTimer = setTimeout(() => {
@@ -227,7 +225,7 @@ export async function start(
 
     // Set substrate client argument version, needed from breaking change.
     // see https://github.com/paritytech/substrate/pull/13384
-    await setSubstrateCliArdsVersion(networkSpec);
+    await setSubstrateCliArgsVersion(networkSpec, client);
 
     // create or copy relay chain spec
     await setupChainSpec(

--- a/javascript/packages/orchestrator/src/providers/k8s/index.ts
+++ b/javascript/packages/orchestrator/src/providers/k8s/index.ts
@@ -5,7 +5,7 @@ import {
   replaceNetworkRef,
 } from "./dynResourceDefinition";
 import { KubeClient, initClient } from "./kubeClient";
-import { setSubstrateCliArdsVersion } from "./substrateCliArgsHelper";
+import { getCliArgsVersion } from "./substrateCliArgsHelper";
 
 export const provider = {
   KubeClient,
@@ -15,5 +15,5 @@ export const provider = {
   setupChainSpec,
   getChainSpecRaw,
   replaceNetworkRef,
-  setSubstrateCliArdsVersion,
+  getCliArgsVersion,
 };

--- a/javascript/packages/orchestrator/src/providers/k8s/substrateCliArgsHelper.ts
+++ b/javascript/packages/orchestrator/src/providers/k8s/substrateCliArgsHelper.ts
@@ -1,10 +1,9 @@
-import { series } from "@zombienet/utils";
-import { ComputedNetwork, SubstrateCliArgsVersion } from "../../types";
+import { SubstrateCliArgsVersion } from "../../types";
 import { getClient } from "../client";
 import { createTempNodeDef, genNodeDef } from "./dynResourceDefinition";
 import { KubeClient } from "./kubeClient";
 
-const getVersion = async (
+export const getCliArgsVersion = async (
   image: string,
   command: string,
 ): Promise<SubstrateCliArgsVersion> => {
@@ -27,57 +26,4 @@ const getVersion = async (
   return logs.includes("--ws-port <PORT>")
     ? SubstrateCliArgsVersion.V0
     : SubstrateCliArgsVersion.V1;
-};
-
-export const setSubstrateCliArdsVersion = async (network: ComputedNetwork) => {
-  // Calculate substrate cli version for each node
-  // and set in the node to use later when we build the cmd.
-  const imgCmdMap = new Map();
-  network.relaychain.nodes.reduce((memo, node) => {
-    const uniq_image_cmd = `${node.image}_${node.command}`;
-    if (!memo.has(uniq_image_cmd))
-      memo.set(uniq_image_cmd, { image: node.image, command: node.command });
-    return memo;
-  }, imgCmdMap);
-
-  network.parachains.reduce((memo, parachain) => {
-    for (const collator of parachain.collators) {
-      const uniq_image_cmd = `${collator.image}_${collator.command}`;
-      if (!memo.has(uniq_image_cmd))
-        memo.set(uniq_image_cmd, {
-          image: collator.image,
-          command: collator.command,
-        });
-    }
-    return memo;
-  }, imgCmdMap);
-
-  // check versions in series
-  const promiseGenerators = [];
-  for (const [, v] of imgCmdMap) {
-    const getVersionPromise = async () => {
-      const version = await getVersion(v.image, v.command);
-      v.version = version;
-      return version;
-    };
-    promiseGenerators.push(getVersionPromise);
-  }
-
-  await series(promiseGenerators, 4);
-
-  // now we need to iterate and set in each node the version
-  // IFF is not set
-  for (const node of network.relaychain.nodes) {
-    if (node.substrateCliArgsVersion) continue;
-    const uniq_image_cmd = `${node.image}_${node.command}`;
-    node.substrateCliArgsVersion = imgCmdMap.get(uniq_image_cmd).version;
-  }
-
-  for (const parachain of network.parachains) {
-    for (const collator of parachain.collators) {
-      if (collator.substrateCliArgsVersion) continue;
-      const uniq_image_cmd = `${collator.image}_${collator.command}`;
-      collator.substrateCliArgsVersion = imgCmdMap.get(uniq_image_cmd).version;
-    }
-  }
 };

--- a/javascript/packages/orchestrator/src/providers/native/index.ts
+++ b/javascript/packages/orchestrator/src/providers/native/index.ts
@@ -5,7 +5,7 @@ import {
   replaceNetworkRef,
 } from "./dynResourceDefinition";
 import { NativeClient, initClient } from "./nativeClient";
-import { setSubstrateCliArdsVersion } from "./substrateCliArgsHelper";
+import { getCliArgsVersion } from "./substrateCliArgsHelper";
 
 export const provider = {
   NativeClient,
@@ -15,5 +15,5 @@ export const provider = {
   setupChainSpec,
   getChainSpecRaw,
   replaceNetworkRef,
-  setSubstrateCliArdsVersion,
+  getCliArgsVersion,
 };

--- a/javascript/packages/orchestrator/src/providers/native/substrateCliArgsHelper.ts
+++ b/javascript/packages/orchestrator/src/providers/native/substrateCliArgsHelper.ts
@@ -1,8 +1,7 @@
-import { series } from "@zombienet/utils";
-import { ComputedNetwork, SubstrateCliArgsVersion } from "../../types";
+import { SubstrateCliArgsVersion } from "../../types";
 import { getClient } from "../client";
 
-const getVersion = async (
+export const getCliArgsVersion = async (
   image: string,
   command: string,
 ): Promise<SubstrateCliArgsVersion> => {
@@ -14,58 +13,4 @@ const getVersion = async (
   return logs.includes("--ws-port <PORT>")
     ? SubstrateCliArgsVersion.V0
     : SubstrateCliArgsVersion.V1;
-};
-
-export const setSubstrateCliArdsVersion = async (network: ComputedNetwork) => {
-  // Calculate substrate cli version for each node
-  // and set in the node to use later when we build the cmd.
-  const imgCmdMap = new Map();
-  network.relaychain.nodes.reduce((memo, node) => {
-    const uniq_image_cmd = `${node.image}_${node.command}`;
-    if (!memo.has(uniq_image_cmd))
-      memo.set(uniq_image_cmd, { image: node.image, command: node.command });
-    return memo;
-  }, imgCmdMap);
-
-  network.parachains.reduce((memo, parachain) => {
-    for (const collator of parachain.collators) {
-      const uniq_image_cmd = `${collator.image}_${collator.command}`;
-      if (!memo.has(uniq_image_cmd))
-        memo.set(uniq_image_cmd, {
-          image: collator.image,
-          command: collator.command,
-        });
-    }
-    return memo;
-  }, imgCmdMap);
-
-  // check versions in series
-  const promiseGenerators = [];
-
-  for (const [, v] of imgCmdMap) {
-    const getVersionPromise = async () => {
-      const version = await getVersion(v.image, v.command);
-      v.version = version;
-      return version;
-    };
-    promiseGenerators.push(getVersionPromise);
-  }
-
-  await series(promiseGenerators, 4);
-
-  // now we need to iterate and set in each node the version
-  // IFF is not set
-  for (const node of network.relaychain.nodes) {
-    if (node.substrateCliArgsVersion) continue;
-    const uniq_image_cmd = `${node.image}_${node.command}`;
-    node.substrateCliArgsVersion = imgCmdMap.get(uniq_image_cmd).version;
-  }
-
-  for (const parachain of network.parachains) {
-    for (const collator of parachain.collators) {
-      if (collator.substrateCliArgsVersion) continue;
-      const uniq_image_cmd = `${collator.image}_${collator.command}`;
-      collator.substrateCliArgsVersion = imgCmdMap.get(uniq_image_cmd).version;
-    }
-  }
 };

--- a/javascript/packages/orchestrator/src/providers/podman/index.ts
+++ b/javascript/packages/orchestrator/src/providers/podman/index.ts
@@ -5,7 +5,7 @@ import {
   replaceNetworkRef,
 } from "./dynResourceDefinition";
 import { PodmanClient, initClient } from "./podmanClient";
-import { setSubstrateCliArdsVersion } from "./substrateCliArgsHelper";
+import { getCliArgsVersion } from "./substrateCliArgsHelper";
 
 export const provider = {
   PodmanClient,
@@ -15,5 +15,5 @@ export const provider = {
   setupChainSpec,
   getChainSpecRaw,
   replaceNetworkRef,
-  setSubstrateCliArdsVersion,
+  getCliArgsVersion,
 };

--- a/javascript/packages/orchestrator/src/providers/podman/substrateCliArgsHelper.ts
+++ b/javascript/packages/orchestrator/src/providers/podman/substrateCliArgsHelper.ts
@@ -1,9 +1,8 @@
-import { series } from "@zombienet/utils";
-import { ComputedNetwork, SubstrateCliArgsVersion } from "../../types";
+import { SubstrateCliArgsVersion } from "../../types";
 import { getClient } from "../client";
 import { createTempNodeDef, genNodeDef } from "./dynResourceDefinition";
 
-const getVersion = async (
+export const getCliArgsVersion = async (
   image: string,
   command: string,
 ): Promise<SubstrateCliArgsVersion> => {
@@ -24,58 +23,4 @@ const getVersion = async (
   return logs.includes("--ws-port <PORT>")
     ? SubstrateCliArgsVersion.V0
     : SubstrateCliArgsVersion.V1;
-};
-
-export const setSubstrateCliArdsVersion = async (network: ComputedNetwork) => {
-  // Calculate substrate cli version for each node
-  // and set in the node to use later when we build the cmd.
-  const imgCmdMap = new Map();
-  network.relaychain.nodes.reduce((memo, node) => {
-    const uniq_image_cmd = `${node.image}_${node.command}`;
-    if (!memo.has(uniq_image_cmd))
-      memo.set(uniq_image_cmd, { image: node.image, command: node.command });
-    return memo;
-  }, imgCmdMap);
-
-  network.parachains.reduce((memo, parachain) => {
-    for (const collator of parachain.collators) {
-      const uniq_image_cmd = `${collator.image}_${collator.command}`;
-      if (!memo.has(uniq_image_cmd))
-        memo.set(uniq_image_cmd, {
-          image: collator.image,
-          command: collator.command,
-        });
-    }
-    return memo;
-  }, imgCmdMap);
-
-  // check versions in series
-  const promiseGenerators = [];
-
-  for (const [, v] of imgCmdMap) {
-    const getVersionPromise = async () => {
-      const version = await getVersion(v.image, v.command);
-      v.version = version;
-      return version;
-    };
-    promiseGenerators.push(getVersionPromise);
-  }
-
-  await series(promiseGenerators, 4);
-
-  // now we need to iterate and set in each node the version
-  // IFF is not set
-  for (const node of network.relaychain.nodes) {
-    if (node.substrateCliArgsVersion) continue;
-    const uniq_image_cmd = `${node.image}_${node.command}`;
-    node.substrateCliArgsVersion = imgCmdMap.get(uniq_image_cmd).version;
-  }
-
-  for (const parachain of network.parachains) {
-    for (const collator of parachain.collators) {
-      if (collator.substrateCliArgsVersion) continue;
-      const uniq_image_cmd = `${collator.image}_${collator.command}`;
-      collator.substrateCliArgsVersion = imgCmdMap.get(uniq_image_cmd).version;
-    }
-  }
 };

--- a/javascript/packages/orchestrator/src/substrateCliArgsHelper.ts
+++ b/javascript/packages/orchestrator/src/substrateCliArgsHelper.ts
@@ -1,0 +1,63 @@
+import { series } from "@zombienet/utils";
+import { getProvider } from "./providers";
+import { Client } from "./providers/client";
+import { ComputedNetwork } from "./types";
+
+export const setSubstrateCliArgsVersion = async (
+  network: ComputedNetwork,
+  client: Client,
+) => {
+  const { getCliArgsVersion } = getProvider(client.providerName);
+  // Calculate substrate cli version for each node
+  // and set in the node to use later when we build the cmd.
+  const imgCmdMap = new Map();
+  network.relaychain.nodes.reduce((memo, node) => {
+    if (node.substrateCliArgsVersion) return memo;
+    const uniq_image_cmd = `${node.image}_${node.command}`;
+    if (!memo.has(uniq_image_cmd))
+      memo.set(uniq_image_cmd, { image: node.image, command: node.command });
+    return memo;
+  }, imgCmdMap);
+
+  network.parachains.reduce((memo, parachain) => {
+    for (const collator of parachain.collators) {
+      if (collator.substrateCliArgsVersion) return memo;
+      const uniq_image_cmd = `${collator.image}_${collator.command}`;
+      if (!memo.has(uniq_image_cmd))
+        memo.set(uniq_image_cmd, {
+          image: collator.image,
+          command: collator.command,
+        });
+    }
+    return memo;
+  }, imgCmdMap);
+
+  // check versions in series
+  const promiseGenerators = [];
+  for (const [, v] of imgCmdMap) {
+    const getVersionPromise = async () => {
+      const version = await getCliArgsVersion(v.image, v.command);
+      v.version = version;
+      return version;
+    };
+    promiseGenerators.push(getVersionPromise);
+  }
+
+  await series(promiseGenerators, 4);
+
+  // now we need to iterate and set in each node the version
+  // IFF is not set
+  for (const node of network.relaychain.nodes) {
+    if (node.substrateCliArgsVersion) continue;
+    const uniq_image_cmd = `${node.image}_${node.command}`;
+    node.substrateCliArgsVersion = imgCmdMap.get(uniq_image_cmd).version;
+  }
+
+  for (const parachain of network.parachains) {
+    for (const collator of parachain.collators) {
+      if (collator.substrateCliArgsVersion) continue;
+      const uniq_image_cmd = `${collator.image}_${collator.command}`;
+      collator.substrateCliArgsVersion = imgCmdMap.get(uniq_image_cmd).version;
+    }
+  }
+};

--- a/javascript/packages/orchestrator/src/types.ts
+++ b/javascript/packages/orchestrator/src/types.ts
@@ -44,6 +44,7 @@ export interface RelayChainConfig {
   default_image?: string;
   default_resources?: Resources;
   default_db_snapshot?: string;
+  default_substrate_cli_args_version?: SubstrateCliArgsVersion;
   chain: string;
   chain_spec_path?: string;
   chain_spec_command?: string;
@@ -77,6 +78,7 @@ export interface NodeConfig {
   p2p_port?: number;
   db_snapshot?: string;
   p2p_cert_hash?: string; // libp2p certhash to use with webrtc transport.
+  substrate_cli_args_version?: SubstrateCliArgsVersion;
 }
 
 export interface NodeGroupConfig {
@@ -89,6 +91,7 @@ export interface NodeGroupConfig {
   count: string | number;
   resources?: Resources;
   db_snapshot?: string;
+  substrate_cli_args_version?: SubstrateCliArgsVersion;
 }
 
 export interface ParachainConfig {


### PR DESCRIPTION
Allow users to set `substrate_cli_args_version` at diff levels for relay and parachains.

fix: #1005 
needed by https://github.com/paritytech/polkadot/issues/7177 

Thanks!