### PR TITLE
hotfix on metrics

### DIFF
--- a/monitoring/app.go
+++ b/monitoring/app.go
@@ -52,6 +52,8 @@ func main() {
 		for {
 			updateMetrics(clientset)
 			time.Sleep(1 * time.Minute)
+			zombiePodsCount.Reset()
+			zombieNamespaceOld.Reset()
 		}
 	}()
 


### PR DESCRIPTION
added reset to metrics that the namespace which removed no longer exist in prometheus metrics