### PR TITLE
fix(orchestrator): clean cache before save network info

### DIFF
--- a/javascript/packages/orchestrator/src/network.ts
+++ b/javascript/packages/orchestrator/src/network.ts
@@ -379,8 +379,8 @@ export class Network {
   }
 
   cleanMetricsCache() {
-    for( const node of Object.values(this.nodesByName)) {
-        node.cleanMetricsCache();
+    for (const node of Object.values(this.nodesByName)) {
+      node.cleanMetricsCache();
     }
   }
 }

--- a/javascript/packages/orchestrator/src/network.ts
+++ b/javascript/packages/orchestrator/src/network.ts
@@ -377,4 +377,10 @@ export class Network {
       },
     );
   }
+
+  cleanMetricsCache() {
+    for( const node of Object.values(this.nodesByName)) {
+        node.cleanMetricsCache();
+    }
+  }
 }

--- a/javascript/packages/orchestrator/src/networkNode.ts
+++ b/javascript/packages/orchestrator/src/networkNode.ts
@@ -542,6 +542,10 @@ export class NetworkNode implements NetworkNodeInterface {
     return spanNames;
   }
 
+  cleanMetricsCache() {
+    this.cachedMetrics = undefined;
+  }
+
   // prevent to search in the same log line twice.
   _dedupLogs(
     logs: string[],

--- a/javascript/packages/orchestrator/src/orchestrator.ts
+++ b/javascript/packages/orchestrator/src/orchestrator.ts
@@ -514,6 +514,8 @@ export async function start(
       `\t 🚀 LAUNCH COMPLETE under namespace ${decorators.green(namespace)} 🚀`,
     );
 
+    // clean cache before dump the info.
+    network.cleanMetricsCache();
     await fs.promises.writeFile(
       `${tmpDir.path}/zombie.json`,
       JSON.stringify(network),


### PR DESCRIPTION
Since we are currently using the metrics to check if the nodes `are up`, we should clean the `cachedMetrics` before dumping the network info to not include those.

Thanks!