### PR TITLE
Fix error when staking bond amount in chainspec is a bigint

### DIFF
--- a/javascript/packages/orchestrator/src/chainSpec.ts
+++ b/javascript/packages/orchestrator/src/chainSpec.ts
@@ -16,7 +16,7 @@ const debug = require("debug")("zombie::chain-spec");
 const JSONStream = require("JSONStream");
 
 // track 1st staking as default;
-let stakingBond: number | undefined;
+let stakingBond: bigint | undefined;
 
 export type KeyType = "session" | "aura" | "grandpa";
 
@@ -73,7 +73,7 @@ export function clearAuthorities(specPath: string) {
 
     // Clear staking
     if (runtimeConfig?.staking) {
-      stakingBond = runtimeConfig.staking.stakers[0][2];
+      stakingBond = BigInt(runtimeConfig.staking.stakers[0][2]);
       runtimeConfig.staking.stakers = [];
       runtimeConfig.staking.invulnerables = [];
       runtimeConfig.staking.validatorCount = 0;
@@ -103,7 +103,7 @@ export async function addBalances(specPath: string, nodes: Node[]) {
         const balanceToAdd = stakingBond
           ? node.validator && node.balance > stakingBond
             ? node.balance
-            : stakingBond! + 1
+            : stakingBond! + BigInt(1)
           : node.balance;
         runtimeConfig.balances.balances.push([stash_key, balanceToAdd]);
 
@@ -206,7 +206,7 @@ export async function addStaking(specPath: string, node: Node) {
     runtimeConfig.staking.stakers.push([
       sr_stash.address,
       sr_stash.address,
-      stakingBond || 1000000000000,
+      stakingBond || BigInt(1000000000000),
       "Validator",
     ]);
 
@@ -354,7 +354,7 @@ export async function generateNominators(
       // create account
       const nom = await generateKeyFromSeed(`nom-${i}`);
       // add to balances
-      const balanceToAdd = stakingBond! + 1;
+      const balanceToAdd = stakingBond! + BigInt(1);
       runtimeConfig.balances.balances.push([nom.address, balanceToAdd]);
       // random nominations
       const count = crypto.randomInt(maxForRandom) % maxNominations;

--- a/javascript/packages/orchestrator/src/types.ts
+++ b/javascript/packages/orchestrator/src/types.ts
@@ -156,7 +156,7 @@ export interface Node {
   name: string;
   key?: string;
   accounts?: any;
-  balance?: number;
+  balance?: bigint;
   command?: string;
   commandWithArgs?: string;
   fullCommand?: string;


### PR DESCRIPTION
Currently if you have a chainspec with a staking bond amount that is large enough to be serialized as a `bigint`, you'll
hit an error in zombienet when calculating the balance for validator nodes:

```
Fail to add balance for nodes: [object Object],[object Object],[object Object],[object Object]

 Unexpected error:       TypeError: Cannot mix BigInt and other types, use explicit conversions
```

This is because the calculation is performed assuming the `stakingBond` is a `number` when it can, in fact, be a `bigint` in the chain spec.

This PR fixes this by performing the balance calculation entirely using `bigint`s.