### PR TITLE
Fix for stateminet -> asset-hub-polkadot

### DIFF
--- a/javascript/packages/orchestrator/src/paras-decorators/index.ts
+++ b/javascript/packages/orchestrator/src/paras-decorators/index.ts
@@ -29,7 +29,8 @@ import oak from "./oak";
 import statemint from "./statemint";
 
 function whichPara(chain: string): PARA {
-  if (chain.includes("statemint")) return PARA.Statemint;
+  if (chain.includes("statemint") || chain.includes("asset-hub-polkadot"))
+    return PARA.Statemint;
   if (/moonbase|moonriver|moonbeam/.test(chain)) return PARA.Moonbeam;
   if (/efinity|matrix/.test(chain)) return PARA.Efinity;
   if (/acala|karura|mandala/.test(chain)) return PARA.Acala;

--- a/javascript/packages/orchestrator/src/spawner.ts
+++ b/javascript/packages/orchestrator/src/spawner.ts
@@ -87,7 +87,10 @@ export const spawnNode = async (
 
     await makeDir(nodeFilesPath, true);
 
-    const isStatemint = parachain && parachain.chain?.includes("statemint");
+    const isStatemint =
+      parachain &&
+      (parachain.chain?.includes("statemint") ||
+        parachain.chain?.includes("asset-hub-polkadot"));
     const keystoreFiles = await generateKeystoreFiles(
       node,
       nodeFilesPath,


### PR DESCRIPTION
this is just hotfix for local running `asset-hub-polkadot-local` parachain,

but maybe "someone" should consider to rename all stuff in zombienet:
- Statemine -> AssetHubKusama
- Statemint -> AssetHubPolkadot