### PR TITLE
fix, ready check for native

### DIFF
--- a/javascript/packages/orchestrator/src/providers/native/nativeClient.ts
+++ b/javascript/packages/orchestrator/src/providers/native/nativeClient.ts
@@ -405,7 +405,7 @@ export class NativeClient extends Client {
       return;
 
     // check if the process is still alive, IFF return node ready
-    // Since could be that the LOG env is set to the minimun.
+    // Since could be that the LOG env is set to the minimum.
     result = await this.runCommand(["-c", `ps ${pid}`], {
       allowFail: true,
     });

--- a/javascript/packages/orchestrator/src/providers/native/nativeClient.ts
+++ b/javascript/packages/orchestrator/src/providers/native/nativeClient.ts
@@ -426,10 +426,7 @@ export class NativeClient extends Client {
 
     logTable.pushToPrint([
       [decorators.cyan("Pod"), decorators.green(nodeName)],
-      [
-        decorators.cyan("Status"),
-        decorators.reverse(decorators.red("Error")),
-      ],
+      [decorators.cyan("Status"), decorators.reverse(decorators.red("Error"))],
       [
         decorators.cyan("Message"),
         decorators.white(`Process: ${pid}, for node: ${nodeName} dies.`),


### PR DESCRIPTION
fix #1117 

This fix the `readiness` check for native provider, allowing to use custom log levels (e.g error).
Thx! 