### PR TITLE
Add vrf key to session keys

### DIFF
--- a/javascript/packages/orchestrator/src/chainSpec.ts
+++ b/javascript/packages/orchestrator/src/chainSpec.ts
@@ -161,6 +161,7 @@ export function getNodeKey(node: Node, useStash = true): GenesisNodeKey {
         beefy: encodeAddress(ec_account.publicKey),
         aura: sr_account.address,
         nimbus: sr_account.address,
+        vrf: sr_account.address,
       },
     ];
 


### PR DESCRIPTION
I'm from manta team, and we plan to retire polkadot-launch with zombienet. 
Our project is using forked nimbus module, we have three keys in pallet-session, like
```rust
pub struct SessionKeys {
    pub aura: Aura,
    pub nimbus: Nimbus,
    pub vrf: Vrf,
}
```
Aura and nimbus key has been supported, so the last obstacle to prevent me to use zombienet is vrf key.
If vrf key is not added to zombienet, I wil get an error when start nodes.
```
Error: Service(Other("Error parsing spec file: missing field `vrf` at line 143 column 13"))
2023-07-22 23:26:52 Building chain spec    
```