### PR TITLE
remove env var from image, to allow other to use easily

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -23,6 +23,7 @@ variables:
   IMAGE_NAME: $DOCKERHUB_REPO/zombienet
   BUILDAH_IMAGE: "quay.io/buildah/stable:v1.29"
   BUILDAH_COMMAND: "buildah --storage-driver overlay2"
+  RUN_IN_CONTAINER: "1"
 
 .kubernetes-env: &kubernetes-env
   image: $CI_IMAGE

--- a/scripts/ci/docker/zombienet_builder.Dockerfile
+++ b/scripts/ci/docker/zombienet_builder.Dockerfile
@@ -72,8 +72,6 @@ RUN mkdir -p /etc/zombie-net
 RUN chown -R nonroot. /etc/zombie-net
 
 # Use the non-root user to run our application
-# Tell run test script that it runs in container
-ENV RUN_IN_CONTAINER 1
 USER nonroot
 # Tini allows us to avoid several Docker edge cases, see https://github.com/krallin/tini.
 ENTRYPOINT ["tini", "--", "bash"]

--- a/scripts/ci/docker/zombienet_injected.Dockerfile
+++ b/scripts/ci/docker/zombienet_injected.Dockerfile
@@ -57,8 +57,6 @@ RUN mkdir -p /etc/zombie-net
 RUN chown -R nonroot. /etc/zombie-net
 
 # Use the non-root user to run our application
-# Tell run test script that it runs in container
-ENV RUN_IN_CONTAINER 1
 USER nonroot
 # Tini allows us to avoid several Docker edge cases, see https://github.com/krallin/tini.
 ENTRYPOINT ["tini", "--", "bash"]


### PR DESCRIPTION
Remove `env var` from image, we should set it in our infra and not in the public image.
