### PR TITLE
Expose WsProvider to scripts as zombie.WsProvider

### DIFF
--- a/javascript/packages/orchestrator/src/test-runner/assertions.ts
+++ b/javascript/packages/orchestrator/src/test-runner/assertions.ts
@@ -1,4 +1,4 @@
-import { ApiPromise, Keyring } from "@polkadot/api";
+import { ApiPromise, Keyring, WsProvider } from "@polkadot/api";
 import { decorators, isValidHttpUrl } from "@zombienet/utils";
 import { assert, expect } from "chai";
 import execa from "execa";
@@ -291,6 +291,7 @@ const CustomJs = ({
     (global as any).zombie = {
       ApiPromise,
       Keyring,
+      WsProvider,
       util: utilCrypto,
       connect,
       registerParachain,


### PR DESCRIPTION
Useful if you can't use `zombie.connect` for whatever reason (eg because you want to pass extra parameters to the `ApiPromise` constructor).