### PR TITLE
fix(orchestrator): Allow to run chains without balances pallet (#1220)

### DIFF
--- a/javascript/packages/orchestrator/src/chainSpec.ts
+++ b/javascript/packages/orchestrator/src/chainSpec.ts
@@ -96,8 +96,12 @@ export async function addBalances(specPath: string, nodes: Node[]) {
   try {
     const chainSpec = readAndParseChainSpec(specPath);
     const runtimeConfig = getRuntimeConfig(chainSpec);
-    if(! runtimeConfig.balances) {
-      console.error(`\n 🚧 ${decorators.yellow("NO 'balances' key in runtimeConfig, skipping...")} 🚧 \n`);
+    if (!runtimeConfig.balances) {
+      console.error(
+        `\n 🚧 ${decorators.yellow(
+          "NO 'balances' key in runtimeConfig, skipping...",
+        )} 🚧 \n`,
+      );
       return;
     }
 

--- a/javascript/packages/orchestrator/src/chainSpec.ts
+++ b/javascript/packages/orchestrator/src/chainSpec.ts
@@ -96,6 +96,11 @@ export async function addBalances(specPath: string, nodes: Node[]) {
   try {
     const chainSpec = readAndParseChainSpec(specPath);
     const runtimeConfig = getRuntimeConfig(chainSpec);
+    if(! runtimeConfig.balances) {
+      console.error(`\n 🚧 ${decorators.yellow("NO 'balances' key in runtimeConfig, skipping...")} 🚧 \n`);
+      return;
+    }
+
     // Create a balance map
     const balanceMap = runtimeConfig.balances.balances.reduce(
       (


### PR DESCRIPTION
Allow to run chains without `balances` pallet. 

fix #1220 

cc: @NachoPal 