### PR TITLE
fix(orchestrator): set undying/adder collators not validators by default

### DIFF
--- a/javascript/packages/orchestrator/src/cmdGenerator.ts
+++ b/javascript/packages/orchestrator/src/cmdGenerator.ts
@@ -270,7 +270,7 @@ export async function genCmd(
     const parachainIdArgIndex = args.findIndex((arg) =>
       arg.includes("--parachain-id"),
     );
-    if( parachainIdArgIndex >=0) args.splice(parachainIdArgIndex, 1);
+    if (parachainIdArgIndex >= 0) args.splice(parachainIdArgIndex, 1);
     args.push(`--parachain-id ${parachainId}`);
   }
 

--- a/javascript/packages/orchestrator/src/cmdGenerator.ts
+++ b/javascript/packages/orchestrator/src/cmdGenerator.ts
@@ -270,7 +270,7 @@ export async function genCmd(
     const parachainIdArgIndex = args.findIndex((arg) =>
       arg.includes("--parachain-id"),
     );
-    args.splice(parachainIdArgIndex, 1);
+    if( parachainIdArgIndex >=0) args.splice(parachainIdArgIndex, 1);
     args.push(`--parachain-id ${parachainId}`);
   }
 

--- a/javascript/packages/orchestrator/src/configGenerator.ts
+++ b/javascript/packages/orchestrator/src/configGenerator.ts
@@ -531,9 +531,12 @@ async function getCollatorNodeFromConfig(
 
   // By default cumulus collators are `validators`, this implies that we will
   // run those with this flag `--collator`.
-  const isValidator = collatorConfig.validator !== undefined ? collatorConfig.validator :
-    cumulusBased ? true :
-    false;
+  const isValidator =
+    collatorConfig.validator !== undefined
+      ? collatorConfig.validator
+      : cumulusBased
+      ? true
+      : false;
 
   const node: Node = {
     name: collatorName,

--- a/javascript/packages/orchestrator/src/configGenerator.ts
+++ b/javascript/packages/orchestrator/src/configGenerator.ts
@@ -529,7 +529,8 @@ async function getCollatorNodeFromConfig(
   const ports = await getPorts(provider, collatorConfig);
   const externalPorts = await getExternalPorts(provider, ports, collatorConfig);
 
-  // By default cumulus collators are `validators`, this implies that we will
+  // IFF the collator have explicit set the validator field we use that value,
+  // if not we set by default cumulus collators as `validators`, this implies that we will
   // run those with this flag `--collator`.
   const isValidator =
     collatorConfig.validator !== undefined

--- a/javascript/packages/orchestrator/src/configGenerator.ts
+++ b/javascript/packages/orchestrator/src/configGenerator.ts
@@ -529,11 +529,17 @@ async function getCollatorNodeFromConfig(
   const ports = await getPorts(provider, collatorConfig);
   const externalPorts = await getExternalPorts(provider, ports, collatorConfig);
 
+  // By default cumulus collators are `validators`, this implies that we will
+  // run those with this flag `--collator`.
+  const isValidator = collatorConfig.validator !== undefined ? collatorConfig.validator :
+    cumulusBased ? true :
+    false;
+
   const node: Node = {
     name: collatorName,
     key: getSha256(collatorName),
     accounts: accountsForNode,
-    validator: collatorConfig.validator !== false ? true : false, // --collator and --force-authoring by default
+    validator: isValidator,
     invulnerable: collatorConfig.invulnerable,
     balance: collatorConfig.balance,
     image: collatorConfig.image || DEFAULT_COLLATOR_IMAGE,


### PR DESCRIPTION
fix #1245. Don't set `undying/adder` collators as validators by default.
