### PR TITLE
chainSpec: support for injecting paras into RuntimeGenesisConfigPatch

### DIFF
--- a/javascript/packages/orchestrator/src/chainSpec.ts
+++ b/javascript/packages/orchestrator/src/chainSpec.ts
@@ -627,7 +627,7 @@ function findAndReplaceConfig(obj1: any, obj2: any) {
 }
 
 export function getRuntimeConfig(chainSpec: any) {
-  // runtime_genesis_config is no logner in ChainSpec after rococo runtime rework (refer to: https://github.com/paritytech/polkadot-sdk/pull/1256)
+  // runtime_genesis_config is no longer in ChainSpec after rococo runtime rework (refer to: https://github.com/paritytech/polkadot-sdk/pull/1256)
   // ChainSpec may contain a RuntimeGenesisConfigPatch
   return (
     chainSpec.genesis.runtimeGenesisConfigPatch ||

--- a/javascript/packages/orchestrator/src/chainSpec.ts
+++ b/javascript/packages/orchestrator/src/chainSpec.ts
@@ -435,7 +435,7 @@ export async function addParachainToGenesis(
     // The config may not contain paras. Since chainspec allows to contain the RuntimeGenesisConfig patch we can inject it.
     else {
       runtimeConfig.paras = { paras: [] };
-      paras = [];
+      paras = runtimeConfig.paras.paras;
     }
     if (paras) {
       const new_para = [

--- a/javascript/packages/orchestrator/src/chainSpec.ts
+++ b/javascript/packages/orchestrator/src/chainSpec.ts
@@ -629,9 +629,11 @@ function findAndReplaceConfig(obj1: any, obj2: any) {
 export function getRuntimeConfig(chainSpec: any) {
   // runtime_genesis_config is no logner in ChainSpec after rococo runtime rework (refer to: https://github.com/paritytech/polkadot-sdk/pull/1256)
   // ChainSpec may contain a RuntimeGenesisConfigPatch
-  return chainSpec.genesis.runtimeGenesisConfigPatch ||
-	  chainSpec.genesis.runtime?.runtime_genesis_config ||
-	  chainSpec.genesis.runtime;
+  return (
+    chainSpec.genesis.runtimeGenesisConfigPatch ||
+    chainSpec.genesis.runtime?.runtime_genesis_config ||
+    chainSpec.genesis.runtime
+  );
 }
 
 export function readAndParseChainSpec(specPath: string) {

--- a/javascript/packages/orchestrator/src/chainSpec.ts
+++ b/javascript/packages/orchestrator/src/chainSpec.ts
@@ -435,7 +435,7 @@ export async function addParachainToGenesis(
     // The config may not contain paras. Since chainspec allows to contain the RuntimeGenesisConfig patch we can inject it.
     else {
       runtimeConfig.paras = { paras: [] };
-      paras = runtimeConfig.paras.paras;
+      paras = [];
     }
     if (paras) {
       const new_para = [

--- a/javascript/packages/orchestrator/src/chainSpec.ts
+++ b/javascript/packages/orchestrator/src/chainSpec.ts
@@ -432,6 +432,11 @@ export async function addParachainToGenesis(
     else if (runtimeConfig.parachainsParas) {
       paras = runtimeConfig.parachainsParas.paras;
     }
+    // The config may not contain paras. Since chainspec allows to contain the RuntimeGenesisConfig patch we can inject it.
+    else {
+      runtimeConfig.paras = { paras: [] };
+      paras = runtimeConfig.paras.paras;
+    }
     if (paras) {
       const new_para = [
         parseInt(para_id),
@@ -622,9 +627,11 @@ function findAndReplaceConfig(obj1: any, obj2: any) {
 }
 
 export function getRuntimeConfig(chainSpec: any) {
-  const runtimeConfig =
-    chainSpec.genesis.runtime?.runtime_genesis_config ||
-    chainSpec.genesis.runtime;
+  // runtime_genesis_config is no logner in ChainSpec after rococo runtime rework (refer to: https://github.com/paritytech/polkadot-sdk/pull/1256)
+  // ChainSpec may contain a RuntimeGenesisConfigPatch
+  const runtimeConfig = chainSpec.genesis.runtimeGenesisConfigPatch ||
+	  chainSpec.genesis.runtime?.runtime_genesis_config ||
+	  chainSpec.genesis.runtime;
 
   return runtimeConfig;
 }

--- a/javascript/packages/orchestrator/src/chainSpec.ts
+++ b/javascript/packages/orchestrator/src/chainSpec.ts
@@ -629,11 +629,9 @@ function findAndReplaceConfig(obj1: any, obj2: any) {
 export function getRuntimeConfig(chainSpec: any) {
   // runtime_genesis_config is no logner in ChainSpec after rococo runtime rework (refer to: https://github.com/paritytech/polkadot-sdk/pull/1256)
   // ChainSpec may contain a RuntimeGenesisConfigPatch
-  const runtimeConfig = chainSpec.genesis.runtimeGenesisConfigPatch ||
+  return chainSpec.genesis.runtimeGenesisConfigPatch ||
 	  chainSpec.genesis.runtime?.runtime_genesis_config ||
 	  chainSpec.genesis.runtime;
-
-  return runtimeConfig;
 }
 
 export function readAndParseChainSpec(specPath: string) {


### PR DESCRIPTION
This PR proposes two fixes for manipulating `chainSpec`, which are required for paritytech/polkadot-sdk#1256:
- `runtime_genesis_config` field is no longer part of RuntimeGenesisConfig for _rococo_ runtimes. It was removed in paritytech/polkadot-sdk#1256, instead of this unified `RuntimeGenesisConfigPatch` field is available.
- the `RuntimeGenesisConfig` patch contained in `ChainSpec` does not contain any default values for runtime genesis config. It only contains values that were overwritten by chain spec author. Since the `para.para` was not changed in rococo chain spec it is not contained in patch. We need to inject it.

For more info on `RuntimeGenesisConfigPatch` please refer to paritytech/polkadot-sdk#1256.

Step towards: https://github.com/paritytech/polkadot-sdk/issues/25