### PR TITLE
fix(orchestrator): wait for artifacts to be ready in temp pods (k8s o…

### DIFF
--- a/javascript/packages/orchestrator/src/paras.ts
+++ b/javascript/packages/orchestrator/src/paras.ts
@@ -282,7 +282,11 @@ export async function generateParachainFiles(
 
     if (client.providerName === "kubernetes") {
       debug("waiting for artifacts been created in pod");
-      await (client as KubeClient).waitLog(podName, podName, NODE_CONTAINER_WAIT_LOG);
+      await (client as KubeClient).waitLog(
+        podName,
+        podName,
+        NODE_CONTAINER_WAIT_LOG,
+      );
     }
 
     if (parachain.genesisStateGenerator) {

--- a/javascript/packages/orchestrator/src/paras.ts
+++ b/javascript/packages/orchestrator/src/paras.ts
@@ -7,6 +7,7 @@ import {
   GENESIS_STATE_FILENAME,
   GENESIS_WASM_FILENAME,
   K8S_WAIT_UNTIL_SCRIPT_SUFIX,
+  NODE_CONTAINER_WAIT_LOG,
   WAIT_UNTIL_SCRIPT_SUFIX,
 } from "./constants";
 import { decorate } from "./paras-decorators";
@@ -14,6 +15,7 @@ import { Providers } from "./providers";
 import { getClient } from "./providers/client";
 import { fileMap } from "./types";
 import { Node, ZombieRole, Parachain } from "./sharedTypes";
+import { KubeClient } from "./providers/k8s/kubeClient";
 
 const debug = require("debug")("zombie::paras");
 
@@ -277,6 +279,11 @@ export async function generateParachainFiles(
     const podName = podDef.metadata.name;
 
     await client.spawnFromDef(podDef, filesToCopyToNodes);
+
+    if (client.providerName === "kubernetes") {
+      debug("waiting for artifacts been created in pod");
+      await (client as KubeClient).waitLog(podName, podName, NODE_CONTAINER_WAIT_LOG);
+    }
 
     if (parachain.genesisStateGenerator) {
       await client.copyFileFromPod(


### PR DESCRIPTION
…nly)

Fix a race condition, trying to `cp` files from the pods that are not ready yet. (example: https://gitlab.parity.io/parity/mirrors/polkadot-sdk/-/jobs/3562385)
