### PR TITLE
fix(orchestrator), fix sanitizing args for cumulus collator

### DIFF
--- a/javascript/packages/orchestrator/src/configGenerator.ts
+++ b/javascript/packages/orchestrator/src/configGenerator.ts
@@ -709,6 +709,10 @@ function sanitizeArgs(
       }
     });
 
+  // put the internal full-node args again
+  if(separatorIndex >= 0) {
+    filteredArgs.push(...args.slice(separatorIndex));
+  }
   return filteredArgs;
 }
 

--- a/javascript/packages/orchestrator/src/configGenerator.ts
+++ b/javascript/packages/orchestrator/src/configGenerator.ts
@@ -710,7 +710,7 @@ function sanitizeArgs(
     });
 
   // put the internal full-node args again
-  if(separatorIndex >= 0) {
+  if (separatorIndex >= 0) {
     filteredArgs.push(...args.slice(separatorIndex));
   }
   return filteredArgs;


### PR DESCRIPTION
Fix #1360 by re-add the internal full-node args for the collator.

cc @skunert this will be included in the next release (I plan to made one today).
Thx!