### PR TITLE
chore(cli): Allow to set concurrency with an env var (ZOMBIE_CONCURRENCY

### DIFF
--- a/javascript/packages/cli/src/actions/spawn.ts
+++ b/javascript/packages/cli/src/actions/spawn.ts
@@ -40,7 +40,8 @@ export async function spawn(
   // By default spawn pods/process in batches of 4,
   // since this shouldn't be a bottleneck in most of the cases,
   // but also can be set with the `-c` flag or with the ZOMBIE_CONCURRENCY env var.
-  const spawnConcurrency = opts.spawnConcurrency || process.env.ZOMBIE_CONCURRENCY || 4;
+  const spawnConcurrency =
+    opts.spawnConcurrency || process.env.ZOMBIE_CONCURRENCY || 4;
   const configPath = resolve(process.cwd(), configFile);
   if (!fs.existsSync(configPath)) {
     console.error(

--- a/javascript/packages/cli/src/actions/spawn.ts
+++ b/javascript/packages/cli/src/actions/spawn.ts
@@ -39,8 +39,8 @@ export async function spawn(
   const monitor = opts.monitor || false;
   // By default spawn pods/process in batches of 4,
   // since this shouldn't be a bottleneck in most of the cases,
-  // but also can be set with the `-c` flag.
-  const spawnConcurrency = opts.spawnConcurrency || 4;
+  // but also can be set with the `-c` flag or with the ZOMBIE_CONCURRENCY env var.
+  const spawnConcurrency = opts.spawnConcurrency || process.env.ZOMBIE_CONCURRENCY || 4;
   const configPath = resolve(process.cwd(), configFile);
   if (!fs.existsSync(configPath)) {
     console.error(

--- a/javascript/packages/cli/src/actions/test.ts
+++ b/javascript/packages/cli/src/actions/test.ts
@@ -26,6 +26,11 @@ export async function test(
   const opts = { ...program.parent.opts(), ...cmdOpts };
   const dir = opts.dir || "";
 
+  // By default spawn pods/process in batches of 4,
+  // since this shouldn't be a bottleneck in most of the cases,
+  // but also can be set with the `-c` flag or with the ZOMBIE_CONCURRENCY env var.
+  const spawnConcurrency = opts.spawnConcurrency || process.env.ZOMBIE_CONCURRENCY || 4;
+
   const extension = testFile.slice(testFile.lastIndexOf(".") + 1);
 
   if (extension !== "zndsl") {
@@ -67,7 +72,7 @@ export async function test(
     testDef,
     providerToUse,
     inCI,
-    opts.spawnConcurrency,
+    spawnConcurrency,
     getLogType(opts.logType),
     runningNetworkSpec,
     dir,

--- a/javascript/packages/cli/src/actions/test.ts
+++ b/javascript/packages/cli/src/actions/test.ts
@@ -29,7 +29,8 @@ export async function test(
   // By default spawn pods/process in batches of 4,
   // since this shouldn't be a bottleneck in most of the cases,
   // but also can be set with the `-c` flag or with the ZOMBIE_CONCURRENCY env var.
-  const spawnConcurrency = opts.spawnConcurrency || process.env.ZOMBIE_CONCURRENCY || 4;
+  const spawnConcurrency =
+    opts.spawnConcurrency || process.env.ZOMBIE_CONCURRENCY || 4;
 
   const extension = testFile.slice(testFile.lastIndexOf(".") + 1);
 

--- a/javascript/packages/orchestrator/src/orchestrator.ts
+++ b/javascript/packages/orchestrator/src/orchestrator.ts
@@ -101,6 +101,7 @@ export async function start(
       opts.spawnConcurrency = 1;
     }
 
+    debug("Concurrecy:", opts.spawnConcurrency);
     debug(JSON.stringify(networkSpec, null, 4));
 
     const { initClient, setupChainSpec, getChainSpecRaw, genChaosDef } =

--- a/javascript/packages/orchestrator/src/orchestrator.ts
+++ b/javascript/packages/orchestrator/src/orchestrator.ts
@@ -101,7 +101,7 @@ export async function start(
       opts.spawnConcurrency = 1;
     }
 
-    debug("Concurrecy:", opts.spawnConcurrency);
+    debug("Concurrency:", opts.spawnConcurrency);
     debug(JSON.stringify(networkSpec, null, 4));
 
     const { initClient, setupChainSpec, getChainSpecRaw, genChaosDef } =


### PR DESCRIPTION
This way we can set the concurrency in gitlab by changing the `env` and not in each test.