### PR TITLE
Updated required repo

### DIFF
--- a/docs/src/development.md
+++ b/docs/src/development.md
@@ -38,7 +38,7 @@ For example:
 node dist/cli.js setup polkadot polkadot-parachain
 ```
 
-> Note: If you are using macOS please clone the [Polkadot repo](https://github.com/paritytech/polkadot) and run it locally. At the moment there is no `polkadot` binary for MacOs.
+> Note: If you are using macOS please clone the [Polkadot-SDK repo](https://github.com/paritytech/polkadot-sdk) and run it locally. At the moment there is no `polkadot` binary for MacOs.
 
 The command above will retrieve the binaries provided and try to download and prepare those binaries for usage.
 At the end of the download, the `setup` script will provide a command to run in your local environment in order to add the directory where the binaries were downloaded in your $PATH var, for example:


### PR DESCRIPTION
## Description

While trying to spawn a network in kubernetes an error related to the use namesapce different then default appeared:

```
 Error:  	 Error: Command failed with exit code 1: kubectl --kubeconfig /Users/wirednkod/.kube/config delete podmonitor zombie-ef4976230e7e09608e35a4bb97d075d0 -n monitoring
Error from server (NotFound): podmonitors.monitoring.coreos.com "zombie-ef4976230e7e09608e35a4bb97d075d0" not found
```

Related [PR #1412](https://github.com/paritytech/zombienet/issues/1412) Error when trying to spawn network in kubernetes

--------------------
## Tasks:

- [ ] Make clear in the docs that you need to be set in the default namespace to start working with zombienet.
- [ ] Print a warning at start that different then default namspace is used