### PR TITLE
feat: allow to use a custom chain-spec generator for plain/raw mode

### DIFF
--- a/javascript/packages/orchestrator/src/configGenerator.ts
+++ b/javascript/packages/orchestrator/src/configGenerator.ts
@@ -182,9 +182,9 @@ export async function generateNetworkSpec(
       .chain_spec_command
       ? config.relaychain.chain_spec_command
       : DEFAULT_CHAIN_SPEC_COMMAND.replace(
-          "{{chainName}}",
-          networkSpec.relaychain.chain,
-        ).replace("{{DEFAULT_COMMAND}}", networkSpec.relaychain.defaultCommand);
+          "{{DEFAULT_COMMAND}}",
+          networkSpec.relaychain.defaultCommand,
+        );
   }
 
   const relayChainBootnodes: string[] = [];

--- a/javascript/packages/orchestrator/src/orchestrator.ts
+++ b/javascript/packages/orchestrator/src/orchestrator.ts
@@ -293,7 +293,8 @@ export async function start(
         namespace,
         networkSpec.relaychain.defaultImage,
         chainName,
-        networkSpec.relaychain.chainSpecCommand || networkSpec.relaychain.defaultCommand,
+        networkSpec.relaychain.chainSpecCommand ||
+          networkSpec.relaychain.defaultCommand,
         chainSpecFullPath,
       );
     } else {

--- a/javascript/packages/orchestrator/src/orchestrator.ts
+++ b/javascript/packages/orchestrator/src/orchestrator.ts
@@ -293,7 +293,7 @@ export async function start(
         namespace,
         networkSpec.relaychain.defaultImage,
         chainName,
-        networkSpec.relaychain.defaultCommand,
+        networkSpec.relaychain.chainSpecCommand || networkSpec.relaychain.defaultCommand,
         chainSpecFullPath,
       );
     } else {

--- a/javascript/packages/orchestrator/src/paras.ts
+++ b/javascript/packages/orchestrator/src/paras.ts
@@ -3,6 +3,7 @@ import fs from "fs";
 import chainSpecFns, { isRawSpec } from "./chainSpec";
 import { getUniqueName } from "./configGenerator";
 import {
+  DEFAULT_CHAIN_SPEC_COMMAND,
   DEFAULT_COLLATOR_IMAGE,
   GENESIS_STATE_FILENAME,
   GENESIS_WASM_FILENAME,
@@ -163,7 +164,11 @@ export async function generateParachainFiles(
         `${parachain.chain ? parachain.chain + "-" : ""}${
           parachain.name
         }-${relayChainName}`,
-        parachain.collators[0].command!,
+        // TODO: does paras need to support external chain generation cmd?
+        DEFAULT_CHAIN_SPEC_COMMAND.replace(
+          "{{DEFAULT_COMMAND}}",
+          parachain.collators[0].command!,
+        ),
         chainSpecFullPath,
       );
     } else {

--- a/javascript/packages/orchestrator/src/providers/k8s/chainSpec.ts
+++ b/javascript/packages/orchestrator/src/providers/k8s/chainSpec.ts
@@ -63,7 +63,7 @@ export async function getChainSpecRaw(
   namespace: string,
   image: string,
   chainName: string,
-  chainCommand: string,
+  chainSpecCommand: string,
   chainFullPath: string,
 ): Promise<any> {
   const client = getClient() as KubeClient;
@@ -77,10 +77,10 @@ export async function getChainSpecRaw(
     client.remoteDir +
     "/" +
     DEFAULT_CHAIN_SPEC_RAW.replace(/{{chainName}}/, chainName);
-  const chainSpecCommandRaw = DEFAULT_CHAIN_SPEC_COMMAND.replace(
-    /{{chainName}}/gi,
-    remoteChainSpecFullPath,
-  ).replace("{{DEFAULT_COMMAND}}", chainCommand);
+    const chainSpecCommandRaw = chainSpecCommand.replace(
+      /{{chainName}}/gi,
+      remoteChainSpecFullPath,
+    );
 
   const fullCommand = `${chainSpecCommandRaw}  --raw > ${remoteChainSpecRawFullPath}`;
   const node = await createTempNodeDef("temp", image, chainName, fullCommand);

--- a/javascript/packages/orchestrator/src/providers/k8s/chainSpec.ts
+++ b/javascript/packages/orchestrator/src/providers/k8s/chainSpec.ts
@@ -1,7 +1,6 @@
 import { promises as fsPromises, writeFileSync } from "fs";
 import {
   DEFAULT_CHAIN_SPEC,
-  DEFAULT_CHAIN_SPEC_COMMAND,
   DEFAULT_CHAIN_SPEC_RAW,
   NODE_CONTAINER_WAIT_LOG,
 } from "../../constants";
@@ -77,10 +76,10 @@ export async function getChainSpecRaw(
     client.remoteDir +
     "/" +
     DEFAULT_CHAIN_SPEC_RAW.replace(/{{chainName}}/, chainName);
-    const chainSpecCommandRaw = chainSpecCommand.replace(
-      /{{chainName}}/gi,
-      remoteChainSpecFullPath,
-    );
+  const chainSpecCommandRaw = chainSpecCommand.replace(
+    /{{chainName}}/gi,
+    remoteChainSpecFullPath,
+  );
 
   const fullCommand = `${chainSpecCommandRaw}  --raw > ${remoteChainSpecRawFullPath}`;
   const node = await createTempNodeDef("temp", image, chainName, fullCommand);

--- a/javascript/packages/orchestrator/src/providers/k8s/chainSpec.ts
+++ b/javascript/packages/orchestrator/src/providers/k8s/chainSpec.ts
@@ -30,7 +30,10 @@ export async function setupChainSpec(
         "/" +
         DEFAULT_CHAIN_SPEC.replace(/{{chainName}}/gi, chainName);
 
-      const fullCommand = `${chainSpecCommand} > ${plainChainSpecOutputFilePath}`;
+      const fullCommand = `${chainSpecCommand.replace(
+        /{{chainName}}/gi,
+        chainName,
+      )} > ${plainChainSpecOutputFilePath}`;
       const node = await createTempNodeDef(
         "temp",
         defaultImage,

--- a/javascript/packages/orchestrator/src/providers/native/chainSpec.ts
+++ b/javascript/packages/orchestrator/src/providers/native/chainSpec.ts
@@ -1,11 +1,7 @@
 import { sleep } from "@zombienet/utils";
 import { promises as fsPromises } from "fs";
 import { readAndParseChainSpec } from "../../chainSpec";
-import {
-  DEFAULT_CHAIN_SPEC,
-  DEFAULT_CHAIN_SPEC_COMMAND,
-  DEFAULT_CHAIN_SPEC_RAW,
-} from "../../constants";
+import { DEFAULT_CHAIN_SPEC, DEFAULT_CHAIN_SPEC_RAW } from "../../constants";
 import { getClient } from "../client";
 import { createTempNodeDef, genNodeDef } from "./dynResourceDefinition";
 
@@ -33,7 +29,10 @@ export async function setupChainSpec(
         "/" +
         DEFAULT_CHAIN_SPEC.replace(/{{chainName}}/gi, chainName);
       // set output of command
-      const fullCommand = `${chainSpecCommand.replace(/{{chainName}}/gi, chainName)} > ${plainChainSpecOutputFilePath}`;
+      const fullCommand = `${chainSpecCommand.replace(
+        /{{chainName}}/gi,
+        chainName,
+      )} > ${plainChainSpecOutputFilePath}`;
       const node = await createTempNodeDef(
         "temp",
         defaultImage,

--- a/javascript/packages/orchestrator/src/providers/native/chainSpec.ts
+++ b/javascript/packages/orchestrator/src/providers/native/chainSpec.ts
@@ -33,7 +33,7 @@ export async function setupChainSpec(
         "/" +
         DEFAULT_CHAIN_SPEC.replace(/{{chainName}}/gi, chainName);
       // set output of command
-      const fullCommand = `${chainSpecCommand} > ${plainChainSpecOutputFilePath}`;
+      const fullCommand = `${chainSpecCommand.replace(/{{chainName}}/gi, chainName)} > ${plainChainSpecOutputFilePath}`;
       const node = await createTempNodeDef(
         "temp",
         defaultImage,
@@ -52,7 +52,7 @@ export async function getChainSpecRaw(
   namespace: string,
   image: string,
   chainName: string,
-  chainCommand: string,
+  chainSpecCommand: string,
   chainFullPath: string,
 ): Promise<any> {
   const client = getClient();
@@ -65,10 +65,10 @@ export async function getChainSpecRaw(
     client.tmpDir +
     "/" +
     DEFAULT_CHAIN_SPEC_RAW.replace(/{{chainName}}/, chainName);
-  const chainSpecCommandRaw = DEFAULT_CHAIN_SPEC_COMMAND.replace(
+  const chainSpecCommandRaw = chainSpecCommand.replace(
     /{{chainName}}/gi,
     remoteChainSpecFullPath,
-  ).replace("{{DEFAULT_COMMAND}}", chainCommand);
+  );
 
   const fullCommand = `${chainSpecCommandRaw}  --raw > ${remoteChainSpecRawFullPath}`;
   const node = await createTempNodeDef("temp", image, chainName, fullCommand);

--- a/javascript/packages/orchestrator/src/providers/podman/chainSpec.ts
+++ b/javascript/packages/orchestrator/src/providers/podman/chainSpec.ts
@@ -1,9 +1,5 @@
 import { sleep } from "@zombienet/utils";
-import {
-  DEFAULT_CHAIN_SPEC,
-  DEFAULT_CHAIN_SPEC_COMMAND,
-  DEFAULT_CHAIN_SPEC_RAW,
-} from "../../constants";
+import { DEFAULT_CHAIN_SPEC, DEFAULT_CHAIN_SPEC_RAW } from "../../constants";
 import { getClient } from "../client";
 import { createTempNodeDef, genNodeDef } from "./dynResourceDefinition";
 const debug = require("debug")("zombie::podman::chain-spec");
@@ -70,9 +66,9 @@ export async function getChainSpecRaw(
     "/" +
     DEFAULT_CHAIN_SPEC_RAW.replace(/{{chainName}}/, chainName);
   const chainSpecCommandRaw = chainSpecCommand.replace(
-      /{{chainName}}/gi,
-      remoteChainSpecFullPath,
-    );
+    /{{chainName}}/gi,
+    remoteChainSpecFullPath,
+  );
 
   const fullCommand = `${chainSpecCommandRaw}  --raw > ${remoteChainSpecRawFullPath}`;
   const node = await createTempNodeDef("temp", image, chainName, fullCommand);

--- a/javascript/packages/orchestrator/src/providers/podman/chainSpec.ts
+++ b/javascript/packages/orchestrator/src/providers/podman/chainSpec.ts
@@ -27,7 +27,10 @@ export async function setupChainSpec(
         "/" +
         DEFAULT_CHAIN_SPEC.replace(/{{chainName}}/gi, chainName);
       // set output of command
-      const fullCommand = `${chainSpecCommand} > ${plainChainSpecOutputFilePath}`;
+      const fullCommand = `${chainSpecCommand.replace(
+        /{{chainName}}/gi,
+        chainName,
+      )} > ${plainChainSpecOutputFilePath}`;
       const node = await createTempNodeDef(
         "temp",
         defaultImage,

--- a/javascript/packages/orchestrator/src/providers/podman/chainSpec.ts
+++ b/javascript/packages/orchestrator/src/providers/podman/chainSpec.ts
@@ -55,7 +55,7 @@ export async function getChainSpecRaw(
   namespace: string,
   image: string,
   chainName: string,
-  chainCommand: string,
+  chainSpecCommand: string,
   chainFullPath: string,
 ): Promise<any> {
   const plainPath = chainFullPath.replace(".json", "-plain.json");
@@ -69,10 +69,10 @@ export async function getChainSpecRaw(
     client.remoteDir +
     "/" +
     DEFAULT_CHAIN_SPEC_RAW.replace(/{{chainName}}/, chainName);
-  const chainSpecCommandRaw = DEFAULT_CHAIN_SPEC_COMMAND.replace(
-    /{{chainName}}/gi,
-    remoteChainSpecFullPath,
-  ).replace("{{DEFAULT_COMMAND}}", chainCommand);
+  const chainSpecCommandRaw = chainSpecCommand.replace(
+      /{{chainName}}/gi,
+      remoteChainSpecFullPath,
+    );
 
   const fullCommand = `${chainSpecCommandRaw}  --raw > ${remoteChainSpecRawFullPath}`;
   const node = await createTempNodeDef("temp", image, chainName, fullCommand);

--- a/javascript/packages/utils/src/fs.ts
+++ b/javascript/packages/utils/src/fs.ts
@@ -89,7 +89,7 @@ function getReplacementInText(content: string): string[] {
   for (const match of content.matchAll(replacementRegex)) {
     // chainName is allowed since we want to use it
     // to replace it in runtime for custom chain spec generator cmd
-    if( match[1] !== "chainName" ) replacements.push(match[1]);
+    if (match[1] !== "chainName") replacements.push(match[1]);
   }
 
   return replacements;

--- a/javascript/packages/utils/src/fs.ts
+++ b/javascript/packages/utils/src/fs.ts
@@ -87,7 +87,9 @@ function getReplacementInText(content: string): string[] {
   // eslint-disable-next-line no-useless-escape
   const replacementRegex = /{{([A-Za-z-_\.]+)}}/gim;
   for (const match of content.matchAll(replacementRegex)) {
-    replacements.push(match[1]);
+    // chainName is allowed since we want to use it
+    // to replace it in runtime for custom chain spec generator cmd
+    if( match[1] !== "chainName" ) replacements.push(match[1]);
   }
 
   return replacements;


### PR DESCRIPTION
This `pr` fix the way we handle chain-spec generation using an external cmd (not the default build-spec from the node). As you may already know, runtimes for polkadot, kusama (**not rococo**) and other system parachain  were moved to `fellowship` [repo](https://github.com/polkadot-fellows/runtimes) so we can't build anymore chains like polkadot-local or kusama-local from the polkadot binary. A new tool is in progress in this [pr](https://github.com/polkadot-fellows/runtimes/pull/51) and a *temporary* tool was introduced [here](https://github.com/polkadot-fellows/runtimes/pull/78). This changes in zombienet allow to use the latest tool and continue supporting spawning chains like `polkadot-local` or `kusama-local`, with the requirement of have this external tool ready to use (for k8s/podman the tool should be included in the pods)

In the future we may need to change ir again to support the final tool developed for generating chain-specs.

cc: @NachoPal I think we talk about this in the past.

Thx!