### PR TITLE
fix(orchestrator): fix matching labels for `podMonitor`

### DIFF
--- a/javascript/packages/orchestrator/static-configs/pod-monitor.yaml
+++ b/javascript/packages/orchestrator/static-configs/pod-monitor.yaml
@@ -13,7 +13,15 @@ spec:
       matchNames:
       - "{{namespace}}"
   selector:
-      matchLabels:
-        zombie-role: authority
+    matchExpressions:
+      - key: "zombie-role"
+        operator: In
+        values:
+          - "authority"
+          - "full-node"
+          - "node"
+          - "collator"
+          - "cumulus-collator"
+          - "bootnode"
   podTargetLabels:
     - instance


### PR DESCRIPTION
Currently we are not matching on the correct zombie-role label. 
