### PR TITLE
`chainSpec`: runtime genesis layout updated

### DIFF
--- a/javascript/packages/orchestrator/src/chainSpec.ts
+++ b/javascript/packages/orchestrator/src/chainSpec.ts
@@ -632,8 +632,8 @@ export function getRuntimeConfig(chainSpec: any) {
   // runtime_genesis_config is no longer in ChainSpec after rococo runtime rework (refer to: https://github.com/paritytech/polkadot-sdk/pull/1256)
   // ChainSpec may contain a RuntimeGenesisConfigPatch
   return (
-    chainSpec.genesis.runtimeGenesis.config ||
-    chainSpec.genesis.runtimeGenesis.patch ||
+    chainSpec.genesis.runtimeGenesis?.config ||
+    chainSpec.genesis.runtimeGenesis?.patch ||
     chainSpec.genesis.runtime?.runtime_genesis_config ||
     chainSpec.genesis.runtime
   );

--- a/javascript/packages/orchestrator/src/chainSpec.ts
+++ b/javascript/packages/orchestrator/src/chainSpec.ts
@@ -632,7 +632,8 @@ export function getRuntimeConfig(chainSpec: any) {
   // runtime_genesis_config is no longer in ChainSpec after rococo runtime rework (refer to: https://github.com/paritytech/polkadot-sdk/pull/1256)
   // ChainSpec may contain a RuntimeGenesisConfigPatch
   return (
-    chainSpec.genesis.runtimeGenesisConfigPatch ||
+    chainSpec.genesis.runtimeGenesis.config ||
+    chainSpec.genesis.runtimeGenesis.patch ||
     chainSpec.genesis.runtime?.runtime_genesis_config ||
     chainSpec.genesis.runtime
   );

--- a/javascript/packages/orchestrator/src/paras.ts
+++ b/javascript/packages/orchestrator/src/paras.ts
@@ -110,9 +110,14 @@ export async function generateParachainFiles(
       if (plainData.genesis.runtime?.parachainInfo?.parachainId)
         plainData.genesis.runtime.parachainInfo.parachainId = parachain.id;
       else if (
-        plainData.genesis.runtimeGenesisConfigPatch?.parachainInfo?.parachainId
+        plainData.genesis.runtimeGenesis?.patch?.parachainInfo?.parachainId
       )
-        plainData.genesis.runtimeGenesisConfigPatch.parachainInfo.parachainId =
+        plainData.genesis.runtimeGenesis.patch.parachainInfo.parachainId =
+          parachain.id;
+      else if (
+        plainData.genesis.runtimeGenesis?.config?.parachainInfo?.parachainId
+      )
+        plainData.genesis.runtimeGenesis.config.parachainInfo.parachainId =
           parachain.id;
 
       writeChainSpec(chainSpecFullPathPlain, plainData);


### PR DESCRIPTION
This is a follow up of discussion about the `code` field in new chain spec, which ended with slight updates to format . The summary of changes together with examples can be found in this comment: https://github.com/paritytech/polkadot-sdk/pull/1256#issuecomment-1789594748.

This PR provides changes required to support new layout.

Related: https://github.com/paritytech/polkadot-sdk/issues/25