### PR TITLE
feat(orchestrator): allow to use 'chain_spec_command' key on parachains

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -256,7 +256,7 @@ paras:
     - echo "Zombienet Paras smoke test"
     - echo "paritypr/zombienet:${CI_COMMIT_SHORT_SHA}"
     - echo "${GH_DIR}"
-    - export DEBUG=zombie*
+    - export DEBUG=zombie
     - export ZOMBIENET_INTEGRATION_TEST_IMAGE="docker.io/paritypr/polkadot-debug:master"
     - export BIFROST_COL_IMAGE=docker.io/bifrostnetwork/bifrost:latest
     - export MOONBEAM_COL_IMAGE=docker.io/purestake/moonbeam:v0.26

--- a/javascript/packages/orchestrator/src/configGenerator.ts
+++ b/javascript/packages/orchestrator/src/configGenerator.ts
@@ -412,6 +412,12 @@ export async function generateNetworkSpec(
         } else {
           parachainSetup.chainSpecPath = chainSpecPath;
         }
+      } else {
+        parachainSetup.chainSpecCommand = parachain.chain_spec_command
+          ? config.relaychain.chain_spec_command
+          : `${collatorBinary} build-spec ${
+              parachain.chain ? "--chain " + parachain.chain : ""
+            } --disable-default-bootnode`;
       }
 
       parachainSetup = {

--- a/javascript/packages/orchestrator/src/configTypes.ts
+++ b/javascript/packages/orchestrator/src/configTypes.ts
@@ -112,6 +112,7 @@ export interface ParachainConfig extends CommonParachainConfig {
   genesis_state_path?: string;
   genesis_state_generator?: string;
   chain_spec_path?: string;
+  chain_spec_command?: string;
   cumulus_based?: boolean;
   bootnodes?: string[];
   prometheus_prefix?: string;

--- a/javascript/packages/orchestrator/src/sharedTypes.ts
+++ b/javascript/packages/orchestrator/src/sharedTypes.ts
@@ -44,6 +44,7 @@ export interface Parachain extends CommonParachainConfig {
   genesisStatePath?: string;
   genesisStateGenerator?: string;
   chainSpecPath?: string;
+  chainSpecCommand?: string;
   specPath?: string;
   wasmPath?: string;
   statePath?: string;


### PR DESCRIPTION
Allow to use `chain_spec_command` in parachains, this will allow users to use an external tool for creating the chain-spec.

cc @NachoPal 

fix #1467 