### PR TITLE
Deactivate gitspiegel - Fail due to token format

### DIFF
--- a/.github/workflows/gitspiegel-trigger.yml
+++ b/.github/workflows/gitspiegel-trigger.yml
@@ -1,20 +1,20 @@
-name: gitspiegel sync
+# name: gitspiegel sync
 
-on:
-  pull_request:
-    types:
-      - opened
-      - synchronize
-      - unlocked
-      - ready_for_review
-      - reopened
+# on:
+#   pull_request:
+#     types:
+#       - opened
+#       - synchronize
+#       - unlocked
+#       - ready_for_review
+#       - reopened
 
-jobs:
-  sync:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Trigger sync via API
-        run: |
-          curl --fail-with-body -XPOST "https://gitspiegel.parity-prod.parity.io/api/v1/mirror/${{ github.repository }}/pull/${{ github.event.number }}" \
-           -H "Content-Type: application/json" \
-           -H "x-auth: ${{ secrets.GITSPIEGEL_TOKEN }}"
+# jobs:
+#   sync:
+#     runs-on: ubuntu-latest
+#     steps:
+#       - name: Trigger sync via API
+#         run: |
+#           curl --fail-with-body -XPOST "https://gitspiegel.parity-prod.parity.io/api/v1/mirror/${{ github.repository }}/pull/${{ github.event.number }}" \
+#            -H "Content-Type: application/json" \
+#            -H "x-auth: ${{ secrets.GITSPIEGEL_TOKEN }}"


### PR DESCRIPTION
I am deactivating gitspiegel for now, as [it is failing](https://github.com/paritytech/zombienet/actions/runs/6781481237/job/18431854502?pr=1442) with `{"error":"Invalid token format"}`

cc @mutantcornholio : Please check before activating again