### PR TITLE
Use chain_spec_path to detect asset hub polkadot

### DIFF
--- a/javascript/packages/orchestrator/src/configGenerator.ts
+++ b/javascript/packages/orchestrator/src/configGenerator.ts
@@ -242,7 +242,7 @@ export async function generateNetworkSpec(
 
   if (config.parachains && config.parachains.length) {
     for (const parachain of config.parachains) {
-      const para: CHAIN = whichChain(parachain.chain || "");
+      const para: CHAIN = whichChain(parachain.chain || parachain.chain_spec_path || "");
 
       let computedStatePath,
         computedStateCommand,

--- a/javascript/packages/orchestrator/src/configGenerator.ts
+++ b/javascript/packages/orchestrator/src/configGenerator.ts
@@ -242,7 +242,9 @@ export async function generateNetworkSpec(
 
   if (config.parachains && config.parachains.length) {
     for (const parachain of config.parachains) {
-      const para: CHAIN = whichChain(parachain.chain || parachain.chain_spec_path || "");
+      const para: CHAIN = whichChain(
+        parachain.chain || parachain.chain_spec_path || "",
+      );
 
       let computedStatePath,
         computedStateCommand,

--- a/javascript/packages/orchestrator/src/spawner.ts
+++ b/javascript/packages/orchestrator/src/spawner.ts
@@ -86,7 +86,9 @@ export const spawnNode = async (
     const isAssetHubPolkadot =
       parachain &&
       (parachain.chain?.includes("statemint") ||
-        parachain.chain?.includes("asset-hub-polkadot"));
+        parachain.chain?.includes("asset-hub-polkadot") ||
+        parachain.chainSpecPath?.includes("statemint") ||
+        parachain.chainSpecPath?.includes("asset-hub-polkadot"));
     const keystoreFiles = await generateKeystoreFiles(
       node,
       nodeFilesPath,


### PR DESCRIPTION
There's no way now to use `polkadot-parachain` with `--chain=asset-hub-polkadot-local`, so we need to use chain spec path. But zombienet only uses the `chain` parameter to detect polkadot AH and generate proper keystore files (for which workaround is to explicitly specify `aura_ed` in `keystore_key_types`) + properly modify chain validators in spec (for which there's no easy workaround).