### PR TITLE
Stop using shell output redirects

### DIFF
--- a/javascript/packages/orchestrator/src/configGenerator.ts
+++ b/javascript/packages/orchestrator/src/configGenerator.ts
@@ -353,7 +353,7 @@ export async function generateNetworkSpec(
           ? parachain.genesis_state_generator
           : `${collatorBinary} ${DEFAULT_GENESIS_GENERATE_SUBCOMMAND}`;
 
-        computedStateCommand += ` > {{CLIENT_REMOTE_DIR}}/${GENESIS_STATE_FILENAME}`;
+        computedStateCommand += ` {{CLIENT_REMOTE_DIR}}/${GENESIS_STATE_FILENAME}`;
       }
 
       if (parachain.genesis_wasm_path) {
@@ -376,7 +376,7 @@ export async function generateNetworkSpec(
           ? parachain.genesis_wasm_generator
           : `${collatorBinary} ${DEFAULT_WASM_GENERATE_SUBCOMMAND}`;
 
-        computedWasmCommand += ` > {{CLIENT_REMOTE_DIR}}/${GENESIS_WASM_FILENAME}`;
+        computedWasmCommand += ` {{CLIENT_REMOTE_DIR}}/${GENESIS_WASM_FILENAME}`;
       }
 
       let parachainSetup: Parachain = {


### PR DESCRIPTION
This tiny PR changes the way that genesis wasm and head data are generated very slightly.

```bash
# Old way
collator-node export-genesis-wasm > some-wasm-file

# New way
collator-node export-genesis-wasm some-wasm-file
```

In the old days, using the shell redirect was the only way to get the file you wanted. But later cumulus added the ability to provide an [output file argument](https://github.com/paritytech/polkadot-sdk/blob/master/cumulus/client/cli/src/lib.rs#L223-L225) and just fallback to printing directly to stdout.

I prefer using the argument because sometimes I find myself needing to print debugging output when actually generating that data, and I don't want my debugging output being redirected to the generated file. (As a concrete example, here is a [current PR](https://github.com/paritytech/polkadot-sdk/pull/2331) where I'm having this problem, and it has happened in the past too.)