### PR TITLE
bump versions for release `v1.3.81`

### DIFF
--- a/javascript/package-lock.json
+++ b/javascript/package-lock.json
@@ -1094,9 +1094,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.9.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.9.1.tgz",
-      "integrity": "sha512-HhmzZh5LSJNS5O8jQKpJ/3ZcrrlG6L70hpGqMIAoM9YVD0YBRNWYsfwcXq8VnSjlNpCpgLzMXdiPo+dxcvSmiA==",
+      "version": "20.9.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.9.2.tgz",
+      "integrity": "sha512-WHZXKFCEyIUJzAwh3NyyTHYSR35SevJ6mZ1nWwJafKtiQbqRTIKSRcw3Ma3acqgsent3RRDqeVwpHntMk+9irg==",
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -6637,11 +6637,11 @@
       }
     },
     "packages/cli": {
-      "version": "1.3.80",
+      "version": "1.3.81",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@zombienet/dsl-parser-wrapper": "^0.1.10",
-        "@zombienet/orchestrator": "^0.0.63",
+        "@zombienet/orchestrator": "^0.0.64",
         "@zombienet/utils": "^0.0.24",
         "cli-progress": "^3.12.0",
         "commander": "^11.1.0",
@@ -6662,7 +6662,7 @@
       }
     },
     "packages/orchestrator": {
-      "version": "0.0.63",
+      "version": "0.0.64",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@polkadot/api": "^10.11.1",

--- a/javascript/packages/cli/package.json
+++ b/javascript/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zombienet/cli",
-  "version": "1.3.80",
+  "version": "1.3.81",
   "description": "ZombieNet aim to be a testing framework for substrate based blockchains, providing a simple cli tool that allow users to spawn and test ephemeral Substrate based networks",
   "main": "dist/index.js",
   "scripts": {
@@ -54,7 +54,7 @@
   },
   "dependencies": {
     "@zombienet/dsl-parser-wrapper": "^0.1.10",
-    "@zombienet/orchestrator": "^0.0.63",
+    "@zombienet/orchestrator": "^0.0.64",
     "@zombienet/utils": "^0.0.24",
     "cli-progress": "^3.12.0",
     "commander": "^11.1.0",

--- a/javascript/packages/orchestrator/package.json
+++ b/javascript/packages/orchestrator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zombienet/orchestrator",
-  "version": "0.0.63",
+  "version": "0.0.64",
   "description": "ZombieNet aim to be a testing framework for substrate based blockchains, providing a simple cli tool that allow users to spawn and test ephemeral Substrate based networks",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Includes:
- Bump polakdot.js modules
- Don't use shell redirections in `export-genesis-*` cmds.