### PR TITLE
fix(test-runner): ignore invalid for perform upgrade tx

### DIFF
--- a/javascript/packages/orchestrator/src/jsapi-helpers/chainUpgrade.ts
+++ b/javascript/packages/orchestrator/src/jsapi-helpers/chainUpgrade.ts
@@ -129,7 +129,7 @@ async function performChainUpgrade(api: ApiPromise, code: string) {
           return resolve();
         } else if (result.isError) {
           unsub();
-          if(result.status.isInvalid) {
+          if (result.status.isInvalid) {
             // Allow `invalid` tx, since we will validate the hash of the `code` later
             // The problem being that there are forks
             // Block X is build with the tx included


### PR DESCRIPTION
This fix the current jobs that are failing because we just reject on `invalid`.  More context in the code and in this [issue](https://github.com/paritytech/polkadot-sdk/issues/1202).
Thx!
