### PR TITLE
fix(orchestrator): [k8s] use ports from config in port-forwarder

### DIFF
--- a/javascript/packages/orchestrator/src/providers/client.ts
+++ b/javascript/packages/orchestrator/src/providers/client.ts
@@ -57,6 +57,7 @@ export abstract class Client {
     port: number,
     identifier: string,
     namespace?: string,
+    localport?: number,
   ): Promise<number>;
   abstract runCommand(
     args: string[],

--- a/javascript/packages/orchestrator/src/providers/k8s/kubeClient.ts
+++ b/javascript/packages/orchestrator/src/providers/k8s/kubeClient.ts
@@ -656,6 +656,7 @@ export class KubeClient extends Client {
     port: number,
     identifier: string,
     namespace?: string,
+    localPort?: number,
   ): Promise<number> {
     let intents = 0;
     const createTunnel = (
@@ -684,6 +685,7 @@ export class KubeClient extends Client {
         port,
         identifier,
         namespace,
+        localPort,
       );
 
       let resolved = false;

--- a/javascript/packages/orchestrator/src/spawner.ts
+++ b/javascript/packages/orchestrator/src/spawner.ts
@@ -140,14 +140,24 @@ export const spawnNode = async (
       node.prometheusPrefix,
     );
   } else {
+    const external_port =
+      node.externalPorts![
+        node.substrateCliArgsVersion == 0 ? "wsPort" : "rpcPort"
+      ];
     const nodeIdentifier = `service/${podDef.metadata.name}`;
     const fwdPort = await client.startPortForwarding(
       endpointPort,
       nodeIdentifier,
+      namespace,
+      external_port,
     );
+
+    const external_port_prom = node.externalPorts!["prometheusPort"];
     const nodePrometheusPort = await client.startPortForwarding(
       PROMETHEUS_PORT,
       nodeIdentifier,
+      namespace,
+      external_port_prom,
     );
 
     const listeningIp = opts.local_ip || LOCALHOST;


### PR DESCRIPTION
fix #1545 
We were not using the port set at config in port-forward commands (k8s only).