### PR TITLE
chore: bump versions for release `v1.3.85`

### DIFF
--- a/javascript/packages/cli/package.json
+++ b/javascript/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zombienet/cli",
-  "version": "1.3.84",
+  "version": "1.3.85",
   "description": "ZombieNet aim to be a testing framework for substrate based blockchains, providing a simple cli tool that allow users to spawn and test ephemeral Substrate based networks",
   "main": "dist/index.js",
   "scripts": {
@@ -54,7 +54,7 @@
   },
   "dependencies": {
     "@zombienet/dsl-parser-wrapper": "^0.1.10",
-    "@zombienet/orchestrator": "^0.0.67",
+    "@zombienet/orchestrator": "^0.0.68",
     "@zombienet/utils": "^0.0.24",
     "cli-progress": "^3.12.0",
     "commander": "^11.1.0",

--- a/javascript/packages/orchestrator/package.json
+++ b/javascript/packages/orchestrator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zombienet/orchestrator",
-  "version": "0.0.67",
+  "version": "0.0.68",
   "description": "ZombieNet aim to be a testing framework for substrate based blockchains, providing a simple cli tool that allow users to spawn and test ephemeral Substrate based networks",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Includes fixes for:

- use ports from config in k8s
- new version of cli-args (supported `--insecure-validator-i-know-what-i-do`)
- Read log promise rejection (#1558)