### PR TITLE
feat(orchestrator): store cmd as file and add fn to read and update c…

### DIFF
--- a/flake-module.nix
+++ b/flake-module.nix
@@ -8,7 +8,7 @@
     ...
   }: let
     # this change on each change of dependencies, unfortunately this hash not yet automatically updated from SRI of package.lock
-    npmDepsHash = "sha256-IwopIBU33FGeyzM9gGFf+fCBajC73xNzUj98Mjb3ANI=";
+    npmDepsHash = "sha256-DI22Ywb0ZWIZAnfjqpkGbA0T0g3MbsvdtoI1OeeXLjQ=";
     ####
 
     # there is officia polkadot on nixpkgs, but it has no local rococo wasm to run

--- a/javascript/packages/orchestrator/zombie-wrapper.sh
+++ b/javascript/packages/orchestrator/zombie-wrapper.sh
@@ -76,7 +76,7 @@ resume() {
     fi
 }
 
-# update start cmd by readin /cfg/zombie.cmd
+# update start cmd by reading /cfg/zombie.cmd
 update_zombie_cmd() {
     NEW_CMD=$($CAT $ZOMBIE_CMD_FILE)
     CMD=($NEW_CMD)

--- a/javascript/packages/orchestrator/zombie-wrapper.sh
+++ b/javascript/packages/orchestrator/zombie-wrapper.sh
@@ -8,6 +8,8 @@ if [ -f /cfg/coreutils ]; then
     LS="/cfg/coreutils ls"
     KILL="/cfg/coreutils kill"
     SLEEP="/cfg/coreutils sleep"
+    ECHO="/cfg/coreutils echo"
+    CAT="/cfg/coreutils cat"
 else
     RM="rm"
     MKFIFO="mkfifo"
@@ -15,6 +17,7 @@ else
     LS="ls"
     KILL="kill"
     SLEEP="sleep"
+    CAT="cat"
 fi
 
 
@@ -44,6 +47,8 @@ child_pid=""
 # get the command to exec
 CMD=($@)
 
+# File to store CMD (and update from there)
+ZOMBIE_CMD_FILE=/cfg/zombie.cmd
 restart() {
     if [ ! -z "${child_pid}" ]; then
         $KILL -9 "$child_pid"
@@ -71,6 +76,16 @@ resume() {
     fi
 }
 
+# update start cmd by readin /cfg/zombie.cmd
+update_zombie_cmd() {
+    NEW_CMD=$($CAT $ZOMBIE_CMD_FILE)
+    CMD=($NEW_CMD)
+}
+
+# Store the cmd and make it available to later usage
+# NOTE: echo without new line to allow to customize the cmd later
+$ECHO -n "${CMD[@]}" > $ZOMBIE_CMD_FILE
+
 # Exec the command and get the child pid
 "${CMD[@]}" &
 child_pid="$!"
@@ -83,7 +98,7 @@ fi;
 # keep listening from the pipe
 while read line <$pipe
 do
-    if [[ "$line" == 'quit' ]]; then
+    if [[ "$line" == "quit" ]]; then
         break
     elif [[ "$line" =~ "restart" ]]; then
         # check if we have timeout between restart
@@ -96,6 +111,8 @@ do
         pause
     elif [[ "$line" == "resume" ]]; then
         resume
+    elif [[ "$line" == "update-cmd" ]]; then
+        update_zombie_cmd
     fi
 done
 


### PR DESCRIPTION
…md to execute by wrapper [k8s]

cc: @mrcnski with this change we can add this logic to an sh script

```bash
if [[ $(grep "insecure-validator-i-know-what-i-do" /cfg/zombie.cmd) ]]; then 
  echo "insecure flag is already part of the cmd";
else
  echo -n " --insecure-validator-i-know-what-i-do" >> /cfg/zombie.cmd;
fi;
echo "update-cmd" > /tmp/zombiepipe;
```

and then just restart from the DSL