### PR TITLE
fix(orchestrator): add 'hrmp' key if missing in the chain-spec

### DIFF
--- a/javascript/packages/orchestrator/src/chainSpec.ts
+++ b/javascript/packages/orchestrator/src/chainSpec.ts
@@ -555,6 +555,14 @@ export async function addHrmpChannelsToGenesis(
       // For retro-compatibility with substrate pre Polkadot 0.9.5
       else if (runtimeConfig.parachainsHrmp) {
         hrmp = runtimeConfig.parachainsHrmp;
+      } else {
+        // No hrmp key in the current chain-spec
+        // let's create the struct and assign
+        runtimeConfig["hrmp"] = {
+          preopenHrmpChannels: []
+        };
+
+        hrmp = runtimeConfig.hrmp;
       }
 
       if (hrmp && hrmp.preopenHrmpChannels) {

--- a/javascript/packages/orchestrator/src/chainSpec.ts
+++ b/javascript/packages/orchestrator/src/chainSpec.ts
@@ -559,7 +559,7 @@ export async function addHrmpChannelsToGenesis(
         // No hrmp key in the current chain-spec
         // let's create the struct and assign
         runtimeConfig["hrmp"] = {
-          preopenHrmpChannels: []
+          preopenHrmpChannels: [],
         };
 
         hrmp = runtimeConfig.hrmp;


### PR DESCRIPTION
Fix #1616 cc @metricaez 

The latest version of polkadot (I think since v1.4.0) could be the case that the chain-spec doesn't includes the `hrmp` key and previously we only allow to change the existing key and if wasn't present we throw an error. This pr allow to add the key if is missing and customize the channels.

Thx! 