### PR TITLE
Revert "chore(deps): bump chai from 4.3.10 to 5.0.0 in /javascript/packages/orchestrator"

### DIFF
--- a/javascript/packages/orchestrator/package.json
+++ b/javascript/packages/orchestrator/package.json
@@ -41,7 +41,7 @@
     "@polkadot/keyring": "^12.6.2",
     "@polkadot/util-crypto": "^12.6.1",
     "@zombienet/utils": "^0.0.24",
-    "chai": "^5.0.0",
+    "chai": "^4.3.10",
     "debug": "^4.3.4",
     "execa": "^5.1.1",
     "fs-extra": "^11.2.0",


### PR DESCRIPTION
Reverts paritytech/zombienet#1630

Breaks the orchestrator
https://github.com/paritytech/zombienet/actions/runs/7357037634/job/20028015261