### PR TITLE
fix(orchestrator): use tmp dir when we create paras artifacts

### DIFF
--- a/flake-module.nix
+++ b/flake-module.nix
@@ -8,7 +8,7 @@
     ...
   }: let
     # this change on each change of dependencies, unfortunately this hash not yet automatically updated from SRI of package.lock
-    npmDepsHash = "sha256-PK1YPfUkLWwzpAQ00S7j5VbfLA8G+zxHaDN4Bjwz7lc=";
+    npmDepsHash = "sha256-RF9jRQFuUNSAkNmpJpiXEpAy5IWBMbd64FVLE4IOavM=";
     ####
 
     # there is officia polkadot on nixpkgs, but it has no local rococo wasm to run

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -8,7 +8,7 @@
     ...
   }: let
     # this change on each change of dependencies, unfortunately this hash not yet automatically updated from SRI of package.lock
-    npmDepsHash = "sha256-RF9jRQFuUNSAkNmpJpiXEpAy5IWBMbd64FVLE4IOavM=";
+    npmDepsHash = "sha256-b5/pRKkx/m+bP1mSuInvV/I7F2ueGjwYbavlGOugfiw=";
     ####
 
     # there is officia polkadot on nixpkgs, but it has no local rococo wasm to run

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -8,7 +8,7 @@
     ...
   }: let
     # this change on each change of dependencies, unfortunately this hash not yet automatically updated from SRI of package.lock
-    npmDepsHash = "sha256-b5/pRKkx/m+bP1mSuInvV/I7F2ueGjwYbavlGOugfiw=";
+    npmDepsHash = "sha256-FMIJ+cCwnskUaqrKVgs8klsQVCwEt9q4FvjhqEg9B28=";
     ####
 
     # there is officia polkadot on nixpkgs, but it has no local rococo wasm to run

--- a/javascript/package-lock.json
+++ b/javascript/package-lock.json
@@ -6732,59 +6732,12 @@
         "node": ">=18"
       }
     },
-    "packages/orchestrator/node_modules/assertion-error": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
-      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "packages/orchestrator/node_modules/brace-expansion": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
       "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
       "dependencies": {
         "balanced-match": "^1.0.0"
-      }
-    },
-    "packages/orchestrator/node_modules/chai": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-5.0.0.tgz",
-      "integrity": "sha512-HO5p0oEKd5M6HEcwOkNAThAE3j960vIZvVcc0t2tI06Dd0ATu69cEnMB2wOhC5/ZyQ6m67w3ePjU/HzXsSsdBA==",
-      "dependencies": {
-        "assertion-error": "^2.0.1",
-        "check-error": "^2.0.0",
-        "deep-eql": "^5.0.1",
-        "loupe": "^3.0.0",
-        "pathval": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "packages/orchestrator/node_modules/check-error": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.0.0.tgz",
-      "integrity": "sha512-tjLAOBHKVxtPoHe/SA7kNOMvhCRdCJ3vETdeY0RuAc9popf+hyaSV6ZEg9hr4cpWF7jmo/JSWEnLDrnijS9Tog==",
-      "engines": {
-        "node": ">= 16"
-      }
-    },
-    "packages/orchestrator/node_modules/deep-eql": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.1.tgz",
-      "integrity": "sha512-nwQCf6ne2gez3o1MxWifqkciwt0zhl0LO1/UwVu4uMBuPmflWM4oQ70XMqHqnBJA+nhzncaqL9HVL6KkHJ28lw==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "packages/orchestrator/node_modules/loupe": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.0.2.tgz",
-      "integrity": "sha512-Tzlkbynv7dtqxTROe54Il+J4e/zG2iehtJGZUYpTv8WzlkW9qyEcE83UhGJCeuF3SCfzHuM5VWhBi47phV3+AQ==",
-      "dependencies": {
-        "get-func-name": "^2.0.1"
       }
     },
     "packages/orchestrator/node_modules/minimatch": {
@@ -6799,14 +6752,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "packages/orchestrator/node_modules/pathval": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.0.tgz",
-      "integrity": "sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==",
-      "engines": {
-        "node": ">= 14.16"
       }
     },
     "packages/utils": {

--- a/javascript/package-lock.json
+++ b/javascript/package-lock.json
@@ -6705,7 +6705,7 @@
         "@polkadot/keyring": "^12.6.2",
         "@polkadot/util-crypto": "^12.6.1",
         "@zombienet/utils": "^0.0.24",
-        "chai": "^5.0.0",
+        "chai": "^4.3.10",
         "debug": "^4.3.4",
         "execa": "^5.1.1",
         "fs-extra": "^11.2.0",

--- a/javascript/packages/orchestrator/package.json
+++ b/javascript/packages/orchestrator/package.json
@@ -41,7 +41,7 @@
     "@polkadot/keyring": "^12.6.2",
     "@polkadot/util-crypto": "^12.6.1",
     "@zombienet/utils": "^0.0.24",
-    "chai": "^5.0.0",
+    "chai": "^4.3.10",
     "debug": "^4.3.4",
     "execa": "^5.1.1",
     "fs-extra": "^11.2.0",

--- a/javascript/packages/orchestrator/src/paras.ts
+++ b/javascript/packages/orchestrator/src/paras.ts
@@ -242,13 +242,18 @@ export async function generateParachainFiles(
         );
       }
 
-      if(client.providerName === "native") {
+      if (client.providerName === "native") {
         // inject a tmp base-path to prevent the use of a pre-existing un-purged data directory.
         // see https://github.com/paritytech/zombienet/issues/1519
         // NOTE: this is only needed in native provides since un k8s/podman the fs is always fresh
         const exportGenesisStateCustomPath = `${client.tmpDir}/export-genesis-state/${parachain.id}`;
-        await fs.promises.mkdir(exportGenesisStateCustomPath, { recursive: true });
-        genesisStateGenerator = injectBasePathInCmd(genesisStateGenerator, exportGenesisStateCustomPath);
+        await fs.promises.mkdir(exportGenesisStateCustomPath, {
+          recursive: true,
+        });
+        genesisStateGenerator = injectBasePathInCmd(
+          genesisStateGenerator,
+          exportGenesisStateCustomPath,
+        );
       }
 
       commands.push(`${genesisStateGenerator}-${parachain.id}`);
@@ -375,7 +380,7 @@ function injectChainInCmd(cmd: string, chain: string): string {
 function injectBasePathInCmd(cmd: string, path: string): string {
   const parts = cmd.split(" ").filter(Boolean);
   // IFF is present don't modify the cmd
-  if( parts.includes("-d") || parts.includes("--base-path")) return cmd;
+  if (parts.includes("-d") || parts.includes("--base-path")) return cmd;
 
   // inject just after the subcommand
   parts.splice(2, 0, `-d ${path}`);

--- a/javascript/packages/orchestrator/src/paras.ts
+++ b/javascript/packages/orchestrator/src/paras.ts
@@ -241,6 +241,16 @@ export async function generateParachainFiles(
           chainSpecPathInNode!,
         );
       }
+
+      if(client.providerName === "native") {
+        // inject a tmp base-path to prevent the use of a pre-existing un-purged data directory.
+        // see https://github.com/paritytech/zombienet/issues/1519
+        // NOTE: this is only needed in native provides since un k8s/podman the fs is always fresh
+        const exportGenesisStateCustomPath = `${client.tmpDir}/export-genesis-state/${parachain.id}`;
+        await fs.promises.mkdir(exportGenesisStateCustomPath, { recursive: true });
+        genesisStateGenerator = injectBasePathInCmd(genesisStateGenerator, exportGenesisStateCustomPath);
+      }
+
       commands.push(`${genesisStateGenerator}-${parachain.id}`);
     }
     if (parachain.genesisWasmGenerator) {
@@ -357,5 +367,17 @@ function injectChainInCmd(cmd: string, chain: string): string {
   const l = parts.length;
   const index = parts[l - 2] == ">" ? l - 2 : l - 1;
   parts.splice(index, 0, `--chain ${chain}`);
+  return parts.join(" ");
+}
+
+// Inject the base-path  (e.g. --base-path <path> or -d <path>)
+// IFF is not present
+function injectBasePathInCmd(cmd: string, path: string): string {
+  const parts = cmd.split(" ").filter(Boolean);
+  // IFF is present don't modify the cmd
+  if( parts.includes("-d") || parts.includes("--base-path")) return cmd;
+
+  // inject just after the subcommand
+  parts.splice(2, 0, `-d ${path}`);
   return parts.join(" ");
 }

--- a/javascript/packages/orchestrator/src/paras.ts
+++ b/javascript/packages/orchestrator/src/paras.ts
@@ -245,7 +245,7 @@ export async function generateParachainFiles(
       if (client.providerName === "native") {
         // inject a tmp base-path to prevent the use of a pre-existing un-purged data directory.
         // see https://github.com/paritytech/zombienet/issues/1519
-        // NOTE: this is only needed in native provides since un k8s/podman the fs is always fresh
+        // NOTE: this is only needed in native provider since un k8s/podman the fs is always fresh
         const exportGenesisStateCustomPath = `${client.tmpDir}/export-genesis-state/${parachain.id}`;
         await fs.promises.mkdir(exportGenesisStateCustomPath, {
           recursive: true,


### PR DESCRIPTION
Use `tmp` dir for `export-genesis-state` cmd.
Fix #1519 
cc: @JoshOrndorff