### PR TITLE
Install procps in Zombienet docker image

### DIFF
--- a/scripts/ci/docker/zombienet_injected.Dockerfile
+++ b/scripts/ci/docker/zombienet_injected.Dockerfile
@@ -9,7 +9,7 @@ LABEL io.parity.image.authors="devops-team@parity.io" \
     io.parity.image.created="${BUILD_DATE}"
 
 RUN apt-get update && \
-    apt-get install -y curl gnupg lsb-release jq tini vim && \
+    apt-get install -y curl gnupg lsb-release jq tini vim procps && \
     apt-get autoremove -y && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Reason: if you'll try to use native provider inside this image (we do that, because we need to deploy multiple relay chains and there's no support for that in other providers), spawn will fail with the "At least one of the nodes fails to start" error. The reason is that the native provider uses the `ps` [here](https://github.com/paritytech/zombienet/blob/e784648b4c619566c3ae880a8885fbe525de0851/javascript/packages/orchestrator/src/providers/native/nativeClient.ts#L137) and it is unavailable in the Docker image.

This isn't critical for us, because we're building image on top of base Zombienet image, but perhaps it'll be useful for other users as well.