### PR TITLE
Add para to registry

### DIFF
--- a/flake-module.nix
+++ b/flake-module.nix
@@ -8,7 +8,7 @@
     ...
   }: let
     # this change on each change of dependencies, unfortunately this hash not yet automatically updated from SRI of package.lock
-    npmDepsHash = "sha256-83mDJ4YCAg8AZjwqtyqx6BULa20ySxcO8xBvSAvB78c=";
+    npmDepsHash = "sha256-YupR/AnxHvBihLvdcWmUHRknW3ReQ01YDd/5uawRuSg=";
     ####
 
     # there is officia polkadot on nixpkgs, but it has no local rococo wasm to run

--- a/javascript/packages/orchestrator/src/chain-decorators/index.ts
+++ b/javascript/packages/orchestrator/src/chain-decorators/index.ts
@@ -102,7 +102,7 @@ const localVDecorators: Decorator = Object.keys(local_v).reduce((memo, fn) => {
   return memo;
 }, Object.create({}));
 
-const MainnetLocalVDecorators: Decorator = Object.keys(local_v).reduce((memo, fn) => {
+const MainnetLocalVDecorators: Decorator = Object.keys(mainnet_local_v).reduce((memo, fn) => {
   memo[fn] = (local_v as Decorator)[fn];
   return memo;
 }, Object.create({}));

--- a/javascript/packages/orchestrator/src/chain-decorators/index.ts
+++ b/javascript/packages/orchestrator/src/chain-decorators/index.ts
@@ -102,10 +102,13 @@ const localVDecorators: Decorator = Object.keys(local_v).reduce((memo, fn) => {
   return memo;
 }, Object.create({}));
 
-const MainnetLocalVDecorators: Decorator = Object.keys(mainnet_local_v).reduce((memo, fn) => {
-  memo[fn] = (local_v as Decorator)[fn];
-  return memo;
-}, Object.create({}));
+const MainnetLocalVDecorators: Decorator = Object.keys(mainnet_local_v).reduce(
+  (memo, fn) => {
+    memo[fn] = (local_v as Decorator)[fn];
+    return memo;
+  },
+  Object.create({}),
+);
 
 const decorators: { [para in CHAIN]: { [fn: string]: Function } } = {
   moonbeam: moonbeamDecorators,
@@ -118,7 +121,7 @@ const decorators: { [para in CHAIN]: { [fn: string]: Function } } = {
   oak: oakDecorators,
   mangata: mangataDecorators,
   local_v: localVDecorators,
-  mainnet_local_v: localVDecorators,
+  mainnet_local_v: MainnetLocalVDecorators,
   generic: {},
 };
 

--- a/javascript/packages/orchestrator/src/chain-decorators/index.ts
+++ b/javascript/packages/orchestrator/src/chain-decorators/index.ts
@@ -10,6 +10,7 @@ enum CHAIN {
   Mangata = "mangata",
   Generic = "generic",
   LocalV = "local_v",
+  MainnetLocalV = "mainnet_local_v",
 }
 
 interface Decorator {
@@ -24,6 +25,7 @@ import bifrost from "./bifrost";
 import efinity from "./efinity";
 import equilibrium from "./equilibrium";
 import local_v from "./local-v";
+import mainnet_local_v from "./mainnet-local-v";
 import mangata from "./mangata";
 import moonbeam from "./moonbeam";
 import oak from "./oak";
@@ -40,6 +42,7 @@ function whichChain(chain: string): CHAIN {
   if (/oak|turing|neumann/.test(chain)) return CHAIN.Oak;
   if (/mangata/.test(chain)) return CHAIN.Mangata;
   if (/local-v/.test(chain)) return CHAIN.LocalV;
+  if (/mainnet-local-v/.test(chain)) return CHAIN.MainnetLocalV;
 
   return CHAIN.Generic;
 }
@@ -99,6 +102,12 @@ const localVDecorators: Decorator = Object.keys(local_v).reduce((memo, fn) => {
   return memo;
 }, Object.create({}));
 
+const MainnetLocalVDecorators: Decorator = Object.keys(local_v).reduce((memo, fn) => {
+  memo[fn] = (local_v as Decorator)[fn];
+  return memo;
+}, Object.create({}));
+);
+
 const decorators: { [para in CHAIN]: { [fn: string]: Function } } = {
   moonbeam: moonbeamDecorators,
   asset_hub_polkadot: assetHubPolkadotDecorators,
@@ -110,6 +119,7 @@ const decorators: { [para in CHAIN]: { [fn: string]: Function } } = {
   oak: oakDecorators,
   mangata: mangataDecorators,
   local_v: localVDecorators,
+  mainnet_local_v: localVDecorators,
   generic: {},
 };
 

--- a/javascript/packages/orchestrator/src/chain-decorators/index.ts
+++ b/javascript/packages/orchestrator/src/chain-decorators/index.ts
@@ -106,7 +106,6 @@ const MainnetLocalVDecorators: Decorator = Object.keys(mainnet_local_v).reduce((
   memo[fn] = (local_v as Decorator)[fn];
   return memo;
 }, Object.create({}));
-);
 
 const decorators: { [para in CHAIN]: { [fn: string]: Function } } = {
   moonbeam: moonbeamDecorators,

--- a/javascript/packages/orchestrator/src/chain-decorators/mainnet-local-v.ts
+++ b/javascript/packages/orchestrator/src/chain-decorators/mainnet-local-v.ts
@@ -1,0 +1,84 @@
+import { Keyring } from "@polkadot/api";
+import { u8aToHex } from "@polkadot/util";
+import { cryptoWaitReady } from "@polkadot/util-crypto";
+import { CreateLogTable, decorators } from "@zombienet/utils";
+import {
+  GenesisNodeKey,
+  getRuntimeConfig,
+  readAndParseChainSpec,
+  writeChainSpec,
+} from "../chainSpec";
+import { generateKeyForNode as _generateKeyForNode } from "../keys";
+import { Node } from "../sharedTypes";
+
+async function generateKeyForNode(nodeName?: string): Promise<any> {
+  const keys = await _generateKeyForNode(nodeName);
+
+  await cryptoWaitReady();
+
+  const eth_keyring = new Keyring({ type: "ethereum" });
+  const eth_account = eth_keyring.createFromUri(
+    `${keys.mnemonic}/m/44'/60'/0'/0/0`,
+  );
+
+  keys.eth_account = {
+    address: eth_account.address,
+    publicKey: u8aToHex(eth_account.publicKey),
+  };
+
+  return keys;
+}
+
+export function getNodeKey(node: Node): GenesisNodeKey {
+  try {
+    const { sr_account, eth_account } = node.accounts;
+
+    const key: GenesisNodeKey = [
+      eth_account.address,
+      eth_account.address,
+      {
+        aura: sr_account.address,
+      },
+    ];
+
+    return key;
+  } catch (err) {
+    console.error(
+      `\n${decorators.red(`Fail to generate key for node: ${node}`)}`,
+    );
+    throw err;
+  }
+}
+
+export async function addCollatorSelection(specPath: string, node: Node) {
+  try {
+    const chainSpec = readAndParseChainSpec(specPath);
+    const runtimeConfig = getRuntimeConfig(chainSpec);
+    if (!runtimeConfig?.collatorSelection?.invulnerables) return;
+
+    const { eth_account } = node.accounts;
+
+    runtimeConfig.collatorSelection.invulnerables.push(eth_account.address);
+
+    new CreateLogTable({
+      colWidths: [30, 20, 70],
+    }).pushToPrint([
+      [
+        decorators.cyan("👤 Added CollatorSelection "),
+        decorators.green(node.name),
+        decorators.magenta(eth_account.address),
+      ],
+    ]);
+
+    writeChainSpec(specPath, chainSpec);
+  } catch (err) {
+    console.error(`\n${decorators.red(`Fail to add collator: ${node}`)}`);
+    throw err;
+  }
+}
+
+export default {
+  getNodeKey,
+  generateKeyForNode,
+  addCollatorSelection,
+};


### PR DESCRIPTION
A few months ago @bernardoaraujor asked to add the `local-v` decorator for a demo parachain for a client [on this PR](https://github.com/paritytech/zombienet/pull/1011). 

We currently need the same setup but to start the mainnet instead of the devnet (which was using --chain local-v) in order to start it with a different chain type.

Once the project goes live we can come back to it and modify the names. This is high priority so I would need this to be merged ASAP --chain mainnet-local-dev