### PR TITLE
Add check for node version

### DIFF
--- a/javascript/packages/cli/src/cli.ts
+++ b/javascript/packages/cli/src/cli.ts
@@ -6,6 +6,7 @@ import { convert } from "./actions/convert";
 import { setup } from "./actions/setup";
 import { spawn } from "./actions/spawn";
 import { test } from "./actions/test";
+import { checkNodeVersion } from "./versionCheck";
 
 const debug = require("debug")("zombie-cli");
 
@@ -17,6 +18,8 @@ let alreadyTryToStop = false;
 const setGlobalNetwork = (globalNetwork: Network) => {
   network = globalNetwork;
 };
+
+checkNodeVersion();
 
 async function handleTermination(userInterrupted = false) {
   process.env.terminating = "1";

--- a/javascript/packages/cli/src/versionCheck.ts
+++ b/javascript/packages/cli/src/versionCheck.ts
@@ -3,11 +3,12 @@ import { decorators } from "@zombienet/utils";
 export const checkNodeVersion = () => {
   const nodeVersion = process.versions.node;
   const requiredNodeVersion = getPackageNodeVersion();
-  if (parseInt(nodeVersion.split(".")[0]) < parseInt(requiredNodeVersion.split(".")[0]) ) {
+  if (
+    parseInt(nodeVersion.split(".")[0]) <
+    parseInt(requiredNodeVersion.split(".")[0])
+  ) {
     console.error(
-      `\n${decorators.red(
-        "Error: ",
-      )} \t ${decorators.bright(
+      `\n${decorators.red("Error: ")} \t ${decorators.bright(
         `Node version ${nodeVersion} is not supported. Please update to Node ${requiredNodeVersion} or above.`,
       )}\n`,
     );
@@ -16,6 +17,8 @@ export const checkNodeVersion = () => {
 };
 
 const getPackageNodeVersion = () => {
-  const { engines: {node}  } = require("../package.json");
+  const {
+    engines: { node },
+  } = require("../package.json");
   return node.replace(/>=\s*/, "");
-}
+};

--- a/javascript/packages/cli/src/versionCheck.ts
+++ b/javascript/packages/cli/src/versionCheck.ts
@@ -1,0 +1,21 @@
+import { decorators } from "@zombienet/utils";
+
+export const checkNodeVersion = () => {
+  const nodeVersion = process.versions.node;
+  const requiredNodeVersion = getPackageNodeVersion();
+  if (parseInt(nodeVersion.split(".")[0]) < parseInt(requiredNodeVersion.split(".")[0]) ) {
+    console.error(
+      `\n${decorators.red(
+        "Error: ",
+      )} \t ${decorators.bright(
+        `Node version ${nodeVersion} is not supported. Please update to Node ${requiredNodeVersion} or above.`,
+      )}\n`,
+    );
+    process.exit(1);
+  }
+};
+
+const getPackageNodeVersion = () => {
+  const { engines: {node}  } = require("../package.json");
+  return node.replace(/>=\s*/, "");
+}


### PR DESCRIPTION
I've spent far too long today trying to debug "waiting for metrics" errors that were due to fetch not being available in node 16. This PR should prevent other people from making the same mistake.