### PR TITLE
Fixes `clearAuthorities` in chainspec when staking genesis is defined

### DIFF
--- a/javascript/packages/orchestrator/src/chainSpec.ts
+++ b/javascript/packages/orchestrator/src/chainSpec.ts
@@ -74,9 +74,13 @@ export function clearAuthorities(specPath: string) {
     if (runtimeConfig?.collatorSelection)
       runtimeConfig.collatorSelection.invulnerables = [];
 
-    // Clear staking
+    // clear staking
     if (runtimeConfig?.staking) {
-      stakingBond = BigInt(runtimeConfig.staking.stakers[0][2]);
+      stakingBond = BigInt(0);
+      for (const staker in runtimeConfig.staking.stakers) {
+        stakingBond += BigInt(runtimeConfig.staking.stakers[staker][2]);
+      }
+
       runtimeConfig.staking.stakers = [];
       runtimeConfig.staking.invulnerables = [];
       runtimeConfig.staking.validatorCount = 0;


### PR DESCRIPTION
This PR fixes the `clearAuthorities` operation in chainspec when staking genesis is defined. I'm not 100% sure if the fix is correct, but at least is does not break when the staking pallet has some genesis configs defined as before.