### PR TITLE
feat(orchestrator): Add node_verifier option to manage how to check r…

### DIFF
--- a/docs/src/network-definition-spec.md
+++ b/docs/src/network-definition-spec.md
@@ -19,6 +19,7 @@ The network config can be provided both in `json` or `toml` format and each sect
 - `tracing_collator_service_port`: (Number, default `3100`) port of the query instance of tempo, **only** available on `kubernetes`.
 - `node_spawn_timeout`: (Number, default per provider) timeout to spawn pod/process.
 - `local_ip`: (String, default "127.0.0.1") ip used for expose local services (rpc/metrics/monitors).
+- `node_verifier`: (String, "None" or "Metric"), Allow to manage how we verify node readiness or disable (None). The default value is `Metric`.
 
 ## `relaychain`
 

--- a/javascript/packages/orchestrator/src/configGenerator.ts
+++ b/javascript/packages/orchestrator/src/configGenerator.ts
@@ -153,6 +153,7 @@ export async function generateNetworkSpec(
   networkSpec.settings = {
     timeout: DEFAULT_GLOBAL_TIMEOUT,
     enable_tracing: true,
+    node_verifier: "Metric",
     ...(config.settings ? config.settings : {}),
   };
 

--- a/javascript/packages/orchestrator/src/configTypes.ts
+++ b/javascript/packages/orchestrator/src/configTypes.ts
@@ -95,6 +95,9 @@ export interface Settings {
   image_pull_policy?: "IfNotPresent" | "Never" | "Always";
   local_ip?: string; // ip used for expose local services (rpc/metrics/monitors)
   global_delay_network_global_settings?: DelayNetworkSettings;
+  // Allow to manage how we verify node readiness or disable (None)
+  // Metric: query prometheus startProcess metric
+  node_verifier?: "None" | "Metric";
 }
 
 export interface GlobalVolume {

--- a/javascript/packages/orchestrator/src/network-helpers/verifier.ts
+++ b/javascript/packages/orchestrator/src/network-helpers/verifier.ts
@@ -28,7 +28,13 @@ export const nodeChecker = async (node: NetworkNode) => {
 // process.
 // Also, worth noting that we are checking the nodes in `batches` of 10
 // at the moment. This value should work ok but we can also optimize later.
-export async function verifyNodes(network: Network) {
+export async function verifyNodes(network: Network, node_verifier = "Metric") {
+  if (node_verifier == "None") {
+    debug!("Node verification disabled!");
+    return;
+  }
+
+  // Metric
   // wait until all the node's are up
   const nodeCheckGenerators = Object.values(network.nodesByName).map(
     (node: NetworkNode) => {
@@ -36,7 +42,7 @@ export async function verifyNodes(network: Network) {
     },
   );
 
-  const nodesOk = await series(nodeCheckGenerators, 10);
+  const nodesOk = await series(nodeCheckGenerators, 15);
   if (!(nodesOk as any[]).every(Boolean))
     throw new Error("At least one of the nodes fails to start");
   debug("All nodes checked ok");

--- a/javascript/packages/orchestrator/src/orchestrator.ts
+++ b/javascript/packages/orchestrator/src/orchestrator.ts
@@ -523,7 +523,7 @@ export async function start(
     // sleep to give time to last node process' to start
     await sleep(2 * 1000);
 
-    await verifyNodes(network);
+    await verifyNodes(network, networkSpec.settings.node_verifier);
 
     // inject chaos to the running network
     if (chaosSpecs.length > 0) await client.injectChaos(chaosSpecs);


### PR DESCRIPTION
…eadiness

- Add `node_verifier` (None|Metric) key to settings to disable the readiness verification. Default value is `Metric`, current behavior.

fix #1730 
