### PR TITLE
Fix(native): don't override logs when restart nodes in native

### DIFF
--- a/javascript/packages/orchestrator/src/providers/native/nativeClient.ts
+++ b/javascript/packages/orchestrator/src/providers/native/nativeClient.ts
@@ -465,7 +465,9 @@ export class NativeClient extends Client {
     if (timeout) await sleep(timeout * 1000);
 
     // start without override the log file.
-    const log = fs.createWriteStream(this.processMap[name].logs,{ flags: "a" });
+    const log = fs.createWriteStream(this.processMap[name].logs, {
+      flags: "a",
+    });
     console.log(["-c", ...this.processMap[name].cmd!]);
     const nodeProcess = spawn(this.command, [
       "-c",

--- a/javascript/packages/orchestrator/src/providers/native/nativeClient.ts
+++ b/javascript/packages/orchestrator/src/providers/native/nativeClient.ts
@@ -464,8 +464,8 @@ export class NativeClient extends Client {
     // sleep
     if (timeout) await sleep(timeout * 1000);
 
-    // start
-    const log = fs.createWriteStream(this.processMap[name].logs);
+    // start without override the log file.
+    const log = fs.createWriteStream(this.processMap[name].logs,{ flags: "a" });
     console.log(["-c", ...this.processMap[name].cmd!]);
     const nodeProcess = spawn(this.command, [
       "-c",


### PR DESCRIPTION
cc @alexggh  