### PR TITLE
Feat(k8s) read logs from host (in `ci`)

### DIFF
--- a/javascript/packages/orchestrator/src/providers/k8s/dynResourceDefinition.ts
+++ b/javascript/packages/orchestrator/src/providers/k8s/dynResourceDefinition.ts
@@ -22,9 +22,10 @@ export async function genBootnodeDef(
 export async function genNodeDef(
   namespace: string,
   nodeSetup: Node,
+  inCI: boolean = false,
 ): Promise<any> {
   const nodeResource = new NodeResource(namespace, nodeSetup);
-  return nodeResource.generateSpec();
+  return nodeResource.generateSpec(inCI);
 }
 
 export function genChaosDef(

--- a/javascript/packages/orchestrator/src/providers/k8s/kubeClient.ts
+++ b/javascript/packages/orchestrator/src/providers/k8s/kubeClient.ts
@@ -775,7 +775,7 @@ export class KubeClient extends Client {
     debug("podId", podId);
     debug("podStatus", podStatus);
     // we can only get compressed files from `Running` pods
-    if(podStatus !== "Running") return [];
+    if (podStatus !== "Running") return [];
 
     // log dir in ci /var/log/pods/<nsName>_<podName>_<podId>/<podName>
     const logsDir = `/var/log/pods/${this.namespace}_${podName}_${podId}/${podName}`;
@@ -830,7 +830,13 @@ export class KubeClient extends Client {
 
   async getPodIdAndStatus(podName: string): Promise<string[]> {
     //  kubectl get pod <podName>  -n <nsName> -o jsonpath='{.metadata.uid}'
-    const args = ["get", "pod", podName, "-o", "jsonpath={.metadata.uid}{\",\"}{.status.phase}"];
+    const args = [
+      "get",
+      "pod",
+      podName,
+      "-o",
+      'jsonpath={.metadata.uid}{","}{.status.phase}',
+    ];
     const result = await this.runCommand(args, {
       scoped: true,
       allowFail: false,

--- a/javascript/packages/orchestrator/src/providers/k8s/kubeClient.ts
+++ b/javascript/packages/orchestrator/src/providers/k8s/kubeClient.ts
@@ -780,7 +780,8 @@ export class KubeClient extends Client {
     // log dir in ci /var/log/pods/<nsName>_<podName>_<podId>/<podName>
     const logsDir = `/var/log/pods/${this.namespace}_${podName}_${podId}/${podName}`;
     // ls dir sorting asc one file per line (only compressed files)
-    const args = ["exec", podName, "--", "ls", "-1", logsDir];
+    // note: use coreutils here since some images (paras) doesn't have `ls`
+    const args = ["exec", podName, "--", "/cfg/coreutils ls", "-1", logsDir];
     const result = await this.runCommand(args, {
       scoped: true,
       allowFail: false,

--- a/javascript/packages/orchestrator/src/providers/k8s/kubeClient.ts
+++ b/javascript/packages/orchestrator/src/providers/k8s/kubeClient.ts
@@ -781,7 +781,7 @@ export class KubeClient extends Client {
     const logsDir = `/var/log/pods/${this.namespace}_${podName}_${podId}/${podName}`;
     // ls dir sorting asc one file per line (only compressed files)
     // note: use coreutils here since some images (paras) doesn't have `ls`
-    const args = ["exec", podName, "--", "/cfg/coreutils ls", "-1", logsDir];
+    const args = ["exec", podName, "--", "/cfg/coreutils", "ls", "-1", logsDir];
     const result = await this.runCommand(args, {
       scoped: true,
       allowFail: false,

--- a/javascript/packages/orchestrator/src/providers/k8s/kubeClient.ts
+++ b/javascript/packages/orchestrator/src/providers/k8s/kubeClient.ts
@@ -744,7 +744,7 @@ export class KubeClient extends Client {
     }
 
     // if we are running in CI, could be the case that k8s had rotate the logs,
-    // so the simple `kubectl logs` will retrive only a part of them.
+    // so the simple `kubectl logs` will retrieve only a part of them.
     // We should read it from host filesystem to ensure we are reading all the logs.
 
     // First get the logs files to check if we need to read from disk or not

--- a/javascript/packages/orchestrator/src/providers/k8s/kubeClient.ts
+++ b/javascript/packages/orchestrator/src/providers/k8s/kubeClient.ts
@@ -748,7 +748,7 @@ export class KubeClient extends Client {
     // We should read it from host filesystem to ensure we are reading all the logs.
 
     // First get the logs files to check if we need to read from disk or not
-    const logFiles = await this.gzipedLogFiles(podName);
+    const logFiles = await this.gzippedLogFiles(podName);
     debug("logFiles", logFiles);
     let logs = "";
     if (logFiles.length === 0) {
@@ -756,7 +756,7 @@ export class KubeClient extends Client {
     } else {
       // need to read the files in order and accumulate in logs
       const promises = logFiles.map((file) =>
-        this.readGzipedLogFile(podName, file),
+        this.readgzippedLogFile(podName, file),
       );
       const results = await Promise.all(promises);
       for (const r of results) {
@@ -770,7 +770,7 @@ export class KubeClient extends Client {
     return logs;
   }
 
-  async gzipedLogFiles(podName: string): Promise<string[]> {
+  async gzippedLogFiles(podName: string): Promise<string[]> {
     const podId = await this.getPodId(podName);
     debug("podId", podId);
     // log dir in ci /var/log/pods/<nsName>_<podName>_<podId>/<podName>
@@ -814,7 +814,7 @@ export class KubeClient extends Client {
     }
   }
 
-  async readGzipedLogFile(podName: string, file: string): Promise<string> {
+  async readgzippedLogFile(podName: string, file: string): Promise<string> {
     const args = ["exec", podName, "--", "zcat", file];
     const result = await this.runCommand(args, {
       scoped: true,

--- a/javascript/packages/orchestrator/src/providers/k8s/resources/nodeResource.ts
+++ b/javascript/packages/orchestrator/src/providers/k8s/resources/nodeResource.ts
@@ -65,7 +65,7 @@ export class NodeResource {
       volMount.push({
         name: "pods",
         mountPath: "/var/log/pods",
-        readOnly: false /* should be true */,
+        readOnly: true /* set to false for debugging */,
       });
     return volMount;
   }

--- a/javascript/packages/orchestrator/src/providers/k8s/resources/nodeResource.ts
+++ b/javascript/packages/orchestrator/src/providers/k8s/resources/nodeResource.ts
@@ -24,6 +24,8 @@ export class NodeResource {
   ) {}
 
   public async generateSpec(inCI: boolean = false) {
+    // DEBUG LOCAL
+    inCI = true;
     const volumes = await this.generateVolumes(inCI);
     const volumeMounts = this.generateVolumesMounts(inCI);
     const containersPorts = await this.generateContainersPorts();
@@ -37,24 +39,34 @@ export class NodeResource {
   }
 
   private async generateVolumes(inCI: boolean): Promise<Volume[]> {
-    let volumes: Volume[] = [
+    const volumes: Volume[] = [
       { name: "tmp-cfg" },
       { name: "tmp-data" },
       { name: "tmp-relay-data" },
     ];
 
-    if( inCI ) volumes.push( { name: "pods", hostPath: { path: "/var/log/pods", type: "" } } );
+    if (inCI)
+      volumes.push({
+        name: "pods",
+        hostPath: { path: "/var/log/pods", type: "" },
+      });
 
     return volumes;
   }
 
   private generateVolumesMounts(inCI: boolean) {
-    let volMount =  [
+    const volMount = [
       { name: "tmp-cfg", mountPath: "/cfg", readOnly: false },
       { name: "tmp-data", mountPath: "/data", readOnly: false },
       { name: "tmp-relay-data", mountPath: "/relay-data", readOnly: false },
     ];
-    if( inCI ) volMount.push( { name: "pods", mountPath: "/var/log/pods", readOnly: true } );
+
+    if (inCI)
+      volMount.push({
+        name: "pods",
+        mountPath: "/var/log/pods",
+        readOnly: false /* should be true */,
+      });
     return volMount;
   }
 

--- a/javascript/packages/orchestrator/src/providers/k8s/resources/types.ts
+++ b/javascript/packages/orchestrator/src/providers/k8s/resources/types.ts
@@ -15,6 +15,7 @@ export interface VolumeMount {
 
 export interface Volume {
   name: string;
+  hostPath?: any;
 }
 
 export interface ContainerPort {

--- a/javascript/packages/orchestrator/src/spawner.ts
+++ b/javascript/packages/orchestrator/src/spawner.ts
@@ -55,7 +55,7 @@ export const spawnNode = async (
   debug(`creating node: ${node.name}`);
   const podDef = await (node.name === "bootnode"
     ? genBootnodeDef(namespace, node)
-    : genNodeDef(namespace, node));
+    : genNodeDef(namespace, node, opts.inCI));
 
   const finalFilesToCopyToNode = [...filesToCopy];
 

--- a/javascript/words.txt
+++ b/javascript/words.txt
@@ -58,6 +58,8 @@ framesystem
 fullpaths
 genshiro
 gurke
+gzipped
+Gzipped
 hasher
 hashers
 hostpath
@@ -177,6 +179,7 @@ willbe
 xcmp
 xinfra
 xzvf
+zcat
 zipkin
 zndsl
 zombienet

--- a/javascript/words.txt
+++ b/javascript/words.txt
@@ -140,6 +140,7 @@ propery
 protobuf
 rawdata
 rawmetric
+readgzipped
 relaychain
 resourse
 runtimes


### PR DESCRIPTION
Fix https://github.com/paritytech/zombienet/issues/1565 / https://github.com/paritytech/zombienet/issues/1652

This pr add the ability to read the pod's logs from disk directly, since those can be rotated by the host (vm) and `kubectl logs` can return the _truncated_ version of those creating false failures.


_NOTE_: This add pr also add the requirement of `zcat` be present in the image (true in our base image) __but__ worth mention to other that are using different images.

cc: @bkchr @michalkucharczyk @skunert 