### PR TITLE
chore: bump version to release

### DIFF
--- a/javascript/packages/cli/package.json
+++ b/javascript/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zombienet/cli",
-  "version": "1.3.95",
+  "version": "1.3.96",
   "description": "ZombieNet aim to be a testing framework for substrate based blockchains, providing a simple cli tool that allow users to spawn and test ephemeral Substrate based networks",
   "main": "dist/index.js",
   "scripts": {
@@ -54,7 +54,7 @@
   },
   "dependencies": {
     "@zombienet/dsl-parser-wrapper": "^0.1.10",
-    "@zombienet/orchestrator": "^0.0.77",
+    "@zombienet/orchestrator": "^0.0.78",
     "@zombienet/utils": "^0.0.24",
     "cli-progress": "^3.12.0",
     "commander": "^11.1.0",

--- a/javascript/packages/orchestrator/package.json
+++ b/javascript/packages/orchestrator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zombienet/orchestrator",
-  "version": "0.0.77",
+  "version": "0.0.78",
   "description": "ZombieNet aim to be a testing framework for substrate based blockchains, providing a simple cli tool that allow users to spawn and test ephemeral Substrate based networks",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
This version includes the fix for reading logs (even when they are rotated) in k8s (https://github.com/paritytech/zombienet/issues/1565 / https://github.com/paritytech/zombienet/issues/1652)