### PR TITLE
chore: push spawning time metric

### DIFF
--- a/javascript/packages/orchestrator/src/orchestrator.ts
+++ b/javascript/packages/orchestrator/src/orchestrator.ts
@@ -49,6 +49,7 @@ import { spawnNode } from "./spawner";
 import { setSubstrateCliArgsVersion } from "./substrateCliArgsHelper";
 import { ComputedNetwork, LaunchConfig } from "./configTypes";
 import { Node, Parachain } from "./sharedTypes";
+import { performance } from "perf_hooks";
 
 const debug = require("debug")("zombie");
 
@@ -74,7 +75,8 @@ export async function start(
   launchConfig: LaunchConfig,
   options?: OrcOptionsInterface,
 ) {
-  console.time("zombie_spawn");
+  const spawnStart = performance.now();
+
   const opts = {
     ...{
       monitor: false,
@@ -535,7 +537,22 @@ export async function start(
     debug(
       `\t 🚀 LAUNCH COMPLETE under namespace ${decorators.green(namespace)} 🚀`,
     );
-    console.timeEnd("zombie_spawn");
+
+    const spawnEnd = performance.now();
+    const spawnElapsedSecs = Math.round((spawnEnd - spawnStart) / 1000);
+    debug(`\t 🕰 Spawn elapsed time: ${spawnElapsedSecs} secs`);
+
+    if (options?.inCI && process.env["CI_JOB_NAME"]) {
+      const jobId = process.env["CI_JOB_ID"];
+      const jobName = process.env["CI_JOB_NAME"];
+      await fetch(
+        "http://zombienet-prometheus-pushgateway.managed-monitoring:9091/metrics/job/zombienet",
+        {
+          method: "POST",
+          body: `spawn_network_ready_secs{job_id="${jobId}", job_name="${jobName}"} ${spawnElapsedSecs}\n`,
+        },
+      );
+    }
 
     // clean cache before dump the info.
     network.cleanMetricsCache();

--- a/javascript/packages/orchestrator/src/orchestrator.ts
+++ b/javascript/packages/orchestrator/src/orchestrator.ts
@@ -540,16 +540,20 @@ export async function start(
 
     const spawnEnd = performance.now();
     const spawnElapsedSecs = Math.round((spawnEnd - spawnStart) / 1000);
-    debug(`\t 🕰 Spawn elapsed time: ${spawnElapsedSecs} secs`);
+    debug(`\t 🕰 [Spawn] elapsed time: ${spawnElapsedSecs} secs`);
 
     if (options?.inCI && process.env["CI_JOB_NAME"]) {
       const jobId = process.env["CI_JOB_ID"];
       const jobName = process.env["CI_JOB_NAME"];
+      const metricName = "zombie_network_ready_secs";
+      const help = `# HELP ${metricName} Elapsed time to spawn the network in seconds`;
+      const type = `# TYPE ${metricName} gauge`;
+      const metricString = `${metricName}{job_id="${jobId}", job_name="${jobName}"} ${spawnElapsedSecs}`;
       await fetch(
-        "http://zombienet-prometheus-pushgateway.managed-monitoring:9091/metrics/job/zombienet",
+        "http://zombienet-prometheus-pushgateway.managed-monitoring:9091/metrics/job/zombie-metrics",
         {
           method: "POST",
-          body: `spawn_network_ready_secs{job_id="${jobId}", job_name="${jobName}"} ${spawnElapsedSecs}\n`,
+          body: [help, type, metricString, "\n"].join("\n"),
         },
       );
     }

--- a/javascript/packages/orchestrator/src/orchestrator.ts
+++ b/javascript/packages/orchestrator/src/orchestrator.ts
@@ -556,7 +556,7 @@ export async function start(
         "http://zombienet-prometheus-pushgateway.managed-monitoring:9091/metrics/job/zombie-metrics",
         {
           method: "POST",
-          body
+          body,
         },
       );
     }

--- a/javascript/packages/orchestrator/src/orchestrator.ts
+++ b/javascript/packages/orchestrator/src/orchestrator.ts
@@ -550,11 +550,13 @@ export async function start(
       const help = `# HELP ${metricName} Elapsed time to spawn the network in seconds`;
       const type = `# TYPE ${metricName} gauge`;
       const metricString = `${metricName}{job_id="${jobId}", job_name="${jobName}", project_name="${projectName}"} ${spawnElapsedSecs}`;
+      const body = [help, type, metricString, "\n"].join("\n");
+      debug!(`Sending metric with content:\n ${body}`);
       await fetch(
         "http://zombienet-prometheus-pushgateway.managed-monitoring:9091/metrics/job/zombie-metrics",
         {
           method: "POST",
-          body: [help, type, metricString, "\n"].join("\n"),
+          body
         },
       );
     }

--- a/javascript/packages/orchestrator/src/orchestrator.ts
+++ b/javascript/packages/orchestrator/src/orchestrator.ts
@@ -545,10 +545,11 @@ export async function start(
     if (options?.inCI && process.env["CI_JOB_NAME"]) {
       const jobId = process.env["CI_JOB_ID"];
       const jobName = process.env["CI_JOB_NAME"];
+      const projectName = process.env["CI_PROJECT_NAME"] || "";
       const metricName = "zombie_network_ready_secs";
       const help = `# HELP ${metricName} Elapsed time to spawn the network in seconds`;
       const type = `# TYPE ${metricName} gauge`;
-      const metricString = `${metricName}{job_id="${jobId}", job_name="${jobName}"} ${spawnElapsedSecs}`;
+      const metricString = `${metricName}{job_id="${jobId}", job_name="${jobName}", project_name="${projectName}"} ${spawnElapsedSecs}`;
       await fetch(
         "http://zombienet-prometheus-pushgateway.managed-monitoring:9091/metrics/job/zombie-metrics",
         {


### PR DESCRIPTION
@emamihe this will push the elapsed time to spawn the network with a few labels to query `by_name` or identify the job_id.

Thx!