### PR TITLE
feat: :wrench: Added StorageHub keys

### DIFF
--- a/docs/src/network-definition-spec.md
+++ b/docs/src/network-definition-spec.md
@@ -146,3 +146,5 @@ The network config can be provided both in `json` or `toml` format and each sect
   - `rand` - `sr`
   - `rate` - `ed`
   - `acco` - `sr`
+  - `bcsv` - `sr`
+  - `ftsv` - `ed`

--- a/javascript/packages/orchestrator/src/chainSpec.ts
+++ b/javascript/packages/orchestrator/src/chainSpec.ts
@@ -179,7 +179,7 @@ export function getNodeKey(node: Node, useStash = true): GenesisNodeKey {
         vrf: sr_account.address,
         mixnet: sr_account.address,
         bcsv: sr_account.address,
-        ftsv: ed_account.address
+        ftsv: ed_account.address,
       },
     ];
 

--- a/javascript/packages/orchestrator/src/chainSpec.ts
+++ b/javascript/packages/orchestrator/src/chainSpec.ts
@@ -178,6 +178,8 @@ export function getNodeKey(node: Node, useStash = true): GenesisNodeKey {
         nimbus: sr_account.address,
         vrf: sr_account.address,
         mixnet: sr_account.address,
+        bcsv: sr_account.address,
+        ftsv: ed_account.address
       },
     ];
 

--- a/javascript/packages/orchestrator/src/constants.ts
+++ b/javascript/packages/orchestrator/src/constants.ts
@@ -126,6 +126,8 @@ const DEFAULT_KEYSTORE_KEY_TYPES: string[] = [
   "nmbs",
   "rand",
   "rate",
+  "bcsv",
+  "ftsv",
 ];
 
 export {

--- a/javascript/packages/orchestrator/src/keys.ts
+++ b/javascript/packages/orchestrator/src/keys.ts
@@ -90,6 +90,8 @@ export async function generateKeystoreFiles(
     rand: node.accounts.sr_account.publicKey, // Randomness (Moonbeam)
     rate: node.accounts.ed_account.publicKey, // Equilibrium rate module
     mixn: node.accounts.sr_account.publicKey, // Mixnet
+    bcsv: node.accounts.sr_account.publicKey, // BlockchainSrvc (StorageHub)
+    ftsv: node.accounts.ed_account.publicKey, // FileTransferSrvc (StorageHub)
   };
 
   // 2 ways keys can be defined:

--- a/javascript/words.txt
+++ b/javascript/words.txt
@@ -11,6 +11,7 @@ availables
 aventus
 backchannel
 baltathar
+bcsv
 bitnami
 blockhash
 blockheight
@@ -55,6 +56,7 @@ ferdie
 fileserver
 finalised
 framesystem
+ftsv
 fullpaths
 genshiro
 gurke
@@ -154,6 +156,7 @@ shiden
 sibl
 simnet
 smoldot
+Srvc
 stakers
 startoflabelname
 statemigration


### PR DESCRIPTION
In StorageHub we are using two new key types for StorageProvider entities. This PR is to integrate them into zombienet's static config so the network is compatible.

_edited_: close https://github.com/paritytech/zombienet/issues/1785