### PR TITLE
fix: launching from local images in kubernetes

### DIFF
--- a/javascript/packages/orchestrator/src/providers/k8s/resources/nodeResource.ts
+++ b/javascript/packages/orchestrator/src/providers/k8s/resources/nodeResource.ts
@@ -156,7 +156,7 @@ export class NodeResource {
       {
         image,
         name,
-        imagePullPolicy: "Always",
+        imagePullPolicy: "IfNotPresent",
         ports,
         env,
         volumeMounts,

--- a/javascript/packages/orchestrator/src/providers/k8s/resources/types.ts
+++ b/javascript/packages/orchestrator/src/providers/k8s/resources/types.ts
@@ -27,7 +27,7 @@ export interface ContainerPort {
 export interface Container {
   image: string;
   name: string;
-  imagePullPolicy?: "Always";
+  imagePullPolicy?: "Always" | "IfNotPresent" | "Never";
   volumeMounts?: VolumeMount[];
   ports?: ContainerPort[];
   command: string[];


### PR DESCRIPTION
When launching using Kubernetes provider (`zombienet -p kubernetes`) and using minikube, I needed to use local image without publishing it.
I can add it to `minikube`, by using `minikube image load image-name:tag` and specify in `zombienet.toml`:
```toml
[settings]
image_pull_policy = "IfNotPresent"
```

However, it'd still fail at the creating bootnodes (and running --help commands), because the policy was to Always download images and they were not published.

Ideally, this option probably should be sourced from `networkSpec.settings.image_pull_policy`, but I left it at this level.

Let me know what you think!

Sort of related to #1829 (as a workaround to not having private registries)