### PR TITLE
Update Install Instructions for NPM and MacOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,27 @@ Zombienet releases are available in `github`. Each one provides an executable fo
 **Note:** Currently, it is only possible to use `podman` for Zombienet users on Linux machines.
 Although `podman` comes with support for macOS, it is done using an internal VM and the Zombienet provider code expects `podman` to be running natively.
 
+### Using Binaries on MacOS
+
+After you have downloaded `zombienet-macos-arm64` or `zombienet-macos-x64`, you will need to:
+
+- Move the binary to your working directory.
+- Rename the binary to just `zombienet` without any `macos-<version>` extension for convenience.
+- Enable the binary to be executable:
+	```bash
+	chmod +x ./zombienet
+	```
+- Remove the binary from quarantine:
+	```bash
+	xattr -d com.apple.quarantine ./zombienet
+	```
+
+Then you should be able to access the binary:
+
+```bash
+./zombienet help
+```
+
 ### Install from NPM
 
 If you have `Node.js`, you can install `zombienet` locally via NPM:

--- a/README.md
+++ b/README.md
@@ -67,6 +67,12 @@ If you have `Node.js`, you can install `zombienet` locally via NPM:
 npm i @zombienet/cli -g
 ```
 
+Then you should be able to access the `zombienet` command:
+
+```
+zombienet help
+```
+
 ## Status
 
 At the moment Zombienet *only* works with `local` chains (e.g. rococo-local, polkadot-local, etc).

--- a/README.md
+++ b/README.md
@@ -35,8 +35,16 @@ Zombienet releases are available in `github`. Each one provides an executable fo
 *without* having `Node.js` installed **but** each `provider` defines its own requirements (e.g.
 `k8s`, `podman`).
 
-**Note:** Currently, it is only possible to use `podman` for Zombienet users on Linux machines. 
+**Note:** Currently, it is only possible to use `podman` for Zombienet users on Linux machines.
 Although `podman` comes with support for macOS, it is done using an internal VM and the Zombienet provider code expects `podman` to be running natively.
+
+### Install from NPM
+
+If you have `Node.js`, you can install `zombienet` locally via NPM:
+
+```bash
+npm i @zombienet/cli -g
+```
 
 ## Status
 
@@ -63,7 +71,7 @@ Zombienet project has it's own `k8s` cluster in GCP, to use it please ping
 Zombienet supports [Podman](https://podman.io/) *rootless* as provider, you only need to have
 `podman` installed in your environment to use and either set in the *network* file or with the
 `--provider` flag in the cli. `Podman` for `zombienet` is currently only supported for Linux machines.
-This is mostly related to paths and directories used by 
+This is mostly related to paths and directories used by
 store configuration (chain-spec) and the data directory.
 
 ### With Native
@@ -200,7 +208,7 @@ message with the `node`s information like this one is shown
 ├─────────────────────────┼────────────────────────────────────────────────────────────────────────────────────────────────────┤
 │ Prometheus Link         │ http://127.0.0.1:44107/metrics                                                                     │
 ├─────────────────────────┼────────────────────────────────────────────────────────────────────────────────────────────────────┤
-│ Log Cmd                 │ tail -f  /tmp/zombie-85391d4649f2829bb26b30d6c0328bcb_-15819-BNFoSs5qusWH/alice.log                │ 
+│ Log Cmd                 │ tail -f  /tmp/zombie-85391d4649f2829bb26b30d6c0328bcb_-15819-BNFoSs5qusWH/alice.log                │
 ├─────────────────────────┴────────────────────────────────────────────────────────────────────────────────────────────────────┤
 │                                                         Node Information                                                     │
 ├─────────────────────────┬────────────────────────────────────────────────────────────────────────────────────────────────────┤
@@ -210,7 +218,7 @@ message with the `node`s information like this one is shown
 ├─────────────────────────┼────────────────────────────────────────────────────────────────────────────────────────────────────┤
 │ Prometheus Link         │ http://127.0.0.1:43831/metrics                                                                     │
 ├─────────────────────────┼────────────────────────────────────────────────────────────────────────────────────────────────────┤
-│ Log Cmd                 │ tail -f  /tmp/zombie-85391d4649f2829bb26b30d6c0328bcb_-15819-BNFoSs5qusWH/bob.log                  │ 
+│ Log Cmd                 │ tail -f  /tmp/zombie-85391d4649f2829bb26b30d6c0328bcb_-15819-BNFoSs5qusWH/bob.log                  │
 ├─────────────────────────┴────────────────────────────────────────────────────────────────────────────────────────────────────┤
 │                                                         Node Information                                                     │
 ├─────────────────────────┬────────────────────────────────────────────────────────────────────────────────────────────────────┤
@@ -220,7 +228,7 @@ message with the `node`s information like this one is shown
 ├─────────────────────────┼────────────────────────────────────────────────────────────────────────────────────────────────────┤
 │ Prometheus Link         │ http://127.0.0.1:38281/metrics                                                                     │
 ├─────────────────────────┼────────────────────────────────────────────────────────────────────────────────────────────────────┤
-│ Log Cmd                 │ tail -f  /tmp/zombie-85391d4649f2829bb26b30d6c0328bcb_-15819-BNFoSs5qusWH/collator01.log           │ 
+│ Log Cmd                 │ tail -f  /tmp/zombie-85391d4649f2829bb26b30d6c0328bcb_-15819-BNFoSs5qusWH/collator01.log           │
 ├─────────────────────────┼────────────────────────────────────────────────────────────────────────────────────────────────────┤
 │ Parachain ID            │ 100                                                                                                │
 └─────────────────────────┴────────────────────────────────────────────────────────────────────────────────────────────────────┘
@@ -346,7 +354,7 @@ For example:
 
 > Note: If you are using macOS please clone the [polkadot-sdk repo](https://github.com/paritytech/polkadot-sdk) and run it locally. At the moment there is no `polkadot` binary for MacOs.
 
-The command above will retrieve the binaries provided and try to download and prepare those binaries for usage. 
+The command above will retrieve the binaries provided and try to download and prepare those binaries for usage.
 At the end of the download, the `setup` script will provide a command to run in your local environment in order to add the directory where the binaries were downloaded in your $PATH var, for example:
 
 ```bash
@@ -379,7 +387,7 @@ Options:
   -c, --spawn-concurrency <concurrency>    Number of concurrent spawning process to launch, default is 1
   -p, --provider <provider>                Override provider to use (choices: "podman", "kubernetes", "native")
   -l, --logType <logType>                  Type of logging - defaults to 'table' (choices: "table", "text", "silent")
-  -d, --dir <path>                         Directory path for placing the network files instead of random temp one 
+  -d, --dir <path>                         Directory path for placing the network files instead of random temp one
                                            (e.g. -d /home/user/my-zombienet)
   -f, --force                              Force override all prompt commands
   -h, --help                               display help for command

--- a/docs/src/install.md
+++ b/docs/src/install.md
@@ -2,6 +2,27 @@
 
 ZombieNet releases are available in [github](https://github.com/paritytech/zombienet/releases). Each release provides executables for both `linux` and `macos` created with [pkg](https://github.com/vercel/pkg) and allows running `zombienet` cli *without* having `Node.js` installed. **But** each `provider` define its own requirements (e.g. k8s, podman).
 
+## Using Binaries on MacOS
+
+After you have downloaded `zombienet-macos-arm64` or `zombienet-macos-x64`, you will need to:
+
+- Move the binary to your working directory.
+- Rename the binary to just `zombienet` without any `macos-<version>` extension for convenience.
+- Enable the binary to be executable:
+	```bash
+	chmod +x ./zombienet
+	```
+- Remove the binary from quarantine:
+	```bash
+	xattr -d com.apple.quarantine ./zombienet
+	```
+
+Then you should be able to access the binary:
+
+```bash
+./zombienet help
+```
+
 ## Using NPM
 
 If you have `Node.js`, you can install `zombienet` locally via NPM:

--- a/docs/src/install.md
+++ b/docs/src/install.md
@@ -31,6 +31,12 @@ If you have `Node.js`, you can install `zombienet` locally via NPM:
 npm i @zombienet/cli@latest -g
 ```
 
+Then you should be able to access the `zombienet` command:
+
+```
+zombienet help
+```
+
 ## Using Nix
 
 [Nix](https://nixos.org/) is a package manager which is available for both `linux` and `macos`.

--- a/docs/src/install.md
+++ b/docs/src/install.md
@@ -2,6 +2,14 @@
 
 ZombieNet releases are available in [github](https://github.com/paritytech/zombienet/releases). Each release provides executables for both `linux` and `macos` created with [pkg](https://github.com/vercel/pkg) and allows running `zombienet` cli *without* having `Node.js` installed. **But** each `provider` define its own requirements (e.g. k8s, podman).
 
+## Using NPM
+
+If you have `Node.js`, you can install `zombienet` locally via NPM:
+
+```bash
+npm i @zombienet/cli@latest -g
+```
+
 ## Using Nix
 
 [Nix](https://nixos.org/) is a package manager which is available for both `linux` and `macos`.


### PR DESCRIPTION
The obvious way for me to install zombenet is through some command like `npm`, not to download an try to get a local binary to execute.

Also added more specific instructions for using the binaries on MacOS