### PR TITLE
Adapt local-v and mainnet-local-v to collatorStaking

### DIFF
--- a/javascript/packages/orchestrator/src/chain-decorators/local-v.ts
+++ b/javascript/packages/orchestrator/src/chain-decorators/local-v.ts
@@ -54,14 +54,10 @@ export async function addCollatorSelection(specPath: string, node: Node) {
   try {
     const chainSpec = readAndParseChainSpec(specPath);
     const runtimeConfig = getRuntimeConfig(chainSpec);
-    if (!runtimeConfig?.collatorSelection?.invulnerables) return;
-
     const { eth_account } = node.accounts;
 
-    if (runtimeConfig.collatorSelection)
-      runtimeConfig.collatorSelection.invulnerables.push(eth_account.address);
-    if (runtimeConfig.collatorStaking)
-      runtimeConfig.collatorStaking.invulnerables.push(eth_account.address);
+    runtimeConfig?.collatorSelection?.invulnerables?.push(eth_account.address);
+    runtimeConfig?.collatorStaking?.invulnerables?.push(eth_account.address);
 
     new CreateLogTable({
       colWidths: [30, 20, 70],

--- a/javascript/packages/orchestrator/src/chain-decorators/mainnet-local-v.ts
+++ b/javascript/packages/orchestrator/src/chain-decorators/mainnet-local-v.ts
@@ -54,11 +54,10 @@ export async function addCollatorSelection(specPath: string, node: Node) {
   try {
     const chainSpec = readAndParseChainSpec(specPath);
     const runtimeConfig = getRuntimeConfig(chainSpec);
-    if (!runtimeConfig?.collatorSelection?.invulnerables) return;
-
     const { eth_account } = node.accounts;
 
-    runtimeConfig.collatorSelection.invulnerables.push(eth_account.address);
+    runtimeConfig?.collatorSelection?.invulnerables?.push(eth_account.address);
+    runtimeConfig?.collatorStaking?.invulnerables?.push(eth_account.address);
 
     new CreateLogTable({
       colWidths: [30, 20, 70],


### PR DESCRIPTION
This PR adapts `local-v` and `mainnet-local-v` to properly work with both `pallet-collator-selection` and `pallet-collator-staking`.