### PR TITLE
bash: use less opionated shebang

### DIFF
--- a/examples/check_creations.sh
+++ b/examples/check_creations.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 KEY_ENCODED=$1
 SCRIPT=$(realpath "$0")

--- a/examples/delay_check.sh
+++ b/examples/delay_check.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ping -q -c 2 8.8.8.8 | tail -1 | awk -F "/" '{print $5}'
 ping -q -c 2 8.8.8.8 | tail -1 | awk -F "/" '{print $5}'

--- a/javascript/packages/orchestrator/zombie-wrapper.sh
+++ b/javascript/packages/orchestrator/zombie-wrapper.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -uxo pipefail
 
 if [ -f /cfg/coreutils ]; then

--- a/javascript/packages/orchestrator/zombie-wrapper.sh
+++ b/javascript/packages/orchestrator/zombie-wrapper.sh
@@ -17,6 +17,7 @@ else
     LS="ls"
     KILL="kill"
     SLEEP="sleep"
+    ECHO="echo"
     CAT="cat"
 fi
 

--- a/scripts/ci/run-test-env-manager.sh
+++ b/scripts/ci/run-test-env-manager.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Based on https://gitlab.parity.io/parity/simnet/-/blob/master/scripts/ci/run-test-environment-manager-v2.sh
 

--- a/scripts/ci/run-test-local-env-manager.sh
+++ b/scripts/ci/run-test-local-env-manager.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Based on https://gitlab.parity.io/parity/simnet/-/blob/master/scripts/ci/run-test-environment-manager-v2.sh
 

--- a/tests/chaos/delay_check.sh
+++ b/tests/chaos/delay_check.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 POD=$1
 PORT=$2 # 9615 for prometheus

--- a/tests/k8s/downloadPolkadot.sh
+++ b/tests/k8s/downloadPolkadot.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euxo pipefail
 


### PR DESCRIPTION
Not every environment has bash installed in `/bin/bash`, so this uses the `env` entrypoint in `/usr/bin` instead to make the bash scripts more portable, e.g. to work on NixOS.