### PR TITLE
bump versions for release `1.3.110`

### DIFF
--- a/javascript/packages/cli/package.json
+++ b/javascript/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zombienet/cli",
-  "version": "1.3.109",
+  "version": "1.3.110",
   "description": "ZombieNet aim to be a testing framework for substrate based blockchains, providing a simple cli tool that allow users to spawn and test ephemeral Substrate based networks",
   "main": "dist/index.js",
   "scripts": {
@@ -56,7 +56,7 @@
   },
   "dependencies": {
     "@zombienet/dsl-parser-wrapper": "^0.1.10",
-    "@zombienet/orchestrator": "^0.0.90",
+    "@zombienet/orchestrator": "^0.0.91",
     "@zombienet/utils": "^0.0.25",
     "cli-progress": "^3.12.0",
     "commander": "^11.1.0",

--- a/javascript/packages/orchestrator/package.json
+++ b/javascript/packages/orchestrator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zombienet/orchestrator",
-  "version": "0.0.90",
+  "version": "0.0.91",
   "description": "ZombieNet aim to be a testing framework for substrate based blockchains, providing a simple cli tool that allow users to spawn and test ephemeral Substrate based networks",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Add:
  - Label `managed-by`
  - Catch errors in `teardown`