### PR TITLE
Add node spec to zombie.json

### DIFF
--- a/javascript/packages/orchestrator/src/spawner.ts
+++ b/javascript/packages/orchestrator/src/spawner.ts
@@ -179,6 +179,8 @@ export const spawnNode = async (
   }
 
   networkNode.group = node.group;
+  // add the full spec
+  networkNode.spec = node;
 
   if (parachain) {
     const paraId = parachain.id;


### PR DESCRIPTION
fix #1883 

cc: @valentinfernandez1

Add: 
   - `spec` key for NetworkNode in zombie.json