### PR TITLE
add support to pass a json as arg for `js-script`

### DIFF
--- a/crates/parser-wrapper/Cargo.toml
+++ b/crates/parser-wrapper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dsl-parser-wrapper"
-version = "0.1.10"
+version = "0.1.11"
 edition = "2021"
 description = "Zombienet DSL parser: produces a test definition, in json format, that can be used with the ZombieNet's test-runnner."
 license = "GPL-3.0-or-later"

--- a/crates/parser-wrapper/todo.md
+++ b/crates/parser-wrapper/todo.md
@@ -1,0 +1,2 @@
+wasm-pack build --target nodejs --scope zombienet
+cd pkg && npm publish --access=public

--- a/crates/parser/Cargo.toml
+++ b/crates/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parser"
-version = "0.0.1"
+version = "0.0.2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/parser/src/lib.rs
+++ b/crates/parser/src/lib.rs
@@ -192,7 +192,7 @@ fn parse_custom_script_rule(
         match inner_record.as_rule() {
             Rule::double_quoted_string => {
                 args = Some(inner_record.as_str().trim_matches('"').to_owned());
-            },
+            }
             Rule::single_quoted_string => {
                 args = Some(inner_record.as_str().trim_matches('\'').to_owned());
             }

--- a/crates/parser/src/lib.rs
+++ b/crates/parser/src/lib.rs
@@ -192,6 +192,9 @@ fn parse_custom_script_rule(
         match inner_record.as_rule() {
             Rule::double_quoted_string => {
                 args = Some(inner_record.as_str().trim_matches('"').to_owned());
+            },
+            Rule::single_quoted_string => {
+                args = Some(inner_record.as_str().trim_matches('\'').to_owned());
             }
             Rule::comparison => {
                 cmp = Some(parse_comparison(inner_record)?);

--- a/crates/parser/src/tests.rs
+++ b/crates/parser/src/tests.rs
@@ -579,6 +579,36 @@ fn custom_js_with_args_parse_ok() {
 }
 
 #[test]
+fn custom_js_with_single_quotes_args_parse_ok() {
+    let line: &str =
+        r#"alice: js-script ./0008-custom.js with '{"a":1,"b":["demo"]}' within 200 seconds"#;
+    let data = r#"{
+        "description": null,
+        "network": "./a.toml",
+        "creds": "config",
+        "assertions": [
+            {
+                "original_line": "alice: js-script ./0008-custom.js with '{\"a\":1,\"b\":[\"demo\"]}' within 200 seconds",
+                "parsed": {
+                  "fn": "CustomJs",
+                  "args": {
+                    "node_name": "alice",
+                    "file_path": "./0008-custom.js",
+                    "custom_args": "{\"a\":1,\"b\":[\"demo\"]}",
+                    "timeout": 200,
+                    "is_ts": false
+                  }
+                }
+            }
+        ]
+    }"#;
+    let t: TestDefinition = serde_json::from_str(data).unwrap();
+
+    let result = parse(&[NETWORK, CREDS, line].join("\n")).unwrap();
+    assert_eq!(result, t);
+}
+
+#[test]
 fn custom_ts_parse_ok() {
     let line: &str = r#"alice: ts-script ./0008-custom-ts.ts within 200 seconds"#;
     let data = r#"{

--- a/crates/parser/src/zombienet.pest
+++ b/crates/parser/src/zombienet.pest
@@ -73,7 +73,7 @@ log_match = { node_name ~ "log line" ~ ("contains"|"matches") ~ match_type? ~ do
 count_log_match = { node_name ~ "count of log lines" ~ ("containing"|"matching") ~ match_type? ~ double_quoted_string ~ "is" ~ (comparison | int+) ~ within? }
 trace = { node_name ~ "trace with traceID" ~ span_id ~ "contains" ~ square_brackets_strings ~ within? }
 system_event = { node_name ~ "system event" ~ ("contains"|"matches") ~ match_type? ~ double_quoted_string ~ within? }
-custom_js = { node_name ~ "js-script" ~ file_path ~ ("with" ~ double_quoted_string)? ~ ( "return" ~ comparison )? ~ within? }
+custom_js = { node_name ~ "js-script" ~ file_path ~ ("with" ~ (double_quoted_string|single_quoted_string))? ~ ( "return" ~ comparison )? ~ within? }
 custom_ts = { node_name ~ "ts-script" ~ file_path ~ ("with" ~ double_quoted_string)? ~ ( "return" ~ comparison )? ~ within? }
 custom_sh = { node_name ~ "run" ~ file_path ~ ("with" ~ double_quoted_string)? ~ ( "return" ~ comparison )? ~ within? }
 

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -8,7 +8,7 @@
     ...
   }: let
     # this change on each change of dependencies, unfortunately this hash not yet automatically updated from SRI of package.lock
-    npmDepsHash = "sha256-JwQKIrLKh3leP+NYI06Rpcn12pidnhAWUB+l/XXKXTs=";
+    npmDepsHash = "sha256-UnHUaTZYwJ1DA9dltMz5bS8spSFUBfqS+IvjzGyHz/k=";
     ####
 
     # there is officia polkadot on nixpkgs, but it has no local rococo wasm to run

--- a/javascript/package-lock.json
+++ b/javascript/package-lock.json
@@ -1573,9 +1573,9 @@
       "link": true
     },
     "node_modules/@zombienet/dsl-parser-wrapper": {
-      "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/@zombienet/dsl-parser-wrapper/-/dsl-parser-wrapper-0.1.10.tgz",
-      "integrity": "sha512-2r2SjanMcNTQiiwTtj/TRO89ek4KoIKGKhgcdHm8+uXPVWuU3tIh/unN8+m51Jnm2jhCLkQQwa5aidvSC02wOg=="
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/@zombienet/dsl-parser-wrapper/-/dsl-parser-wrapper-0.1.11.tgz",
+      "integrity": "sha512-gUDuFLMjB30ghUFWeOIP4i7S+XthPik07tkmg0EJR5Jm2WWAfHP7zaaPFGrxBFlsCwlgLlbDOLRvNfKUNMXnfg=="
     },
     "node_modules/@zombienet/orchestrator": {
       "resolved": "packages/orchestrator",
@@ -6932,11 +6932,11 @@
     },
     "packages/cli": {
       "name": "@zombienet/cli",
-      "version": "1.3.113",
+      "version": "1.3.114",
       "license": "GPL-3.0-or-later",
       "dependencies": {
-        "@zombienet/dsl-parser-wrapper": "^0.1.10",
-        "@zombienet/orchestrator": "^0.0.94",
+        "@zombienet/dsl-parser-wrapper": "^0.1.11",
+        "@zombienet/orchestrator": "^0.0.95",
         "@zombienet/utils": "^0.0.25",
         "cli-progress": "^3.12.0",
         "commander": "^11.1.0",
@@ -6958,7 +6958,7 @@
     },
     "packages/orchestrator": {
       "name": "@zombienet/orchestrator",
-      "version": "0.0.94",
+      "version": "0.0.95",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@polkadot/api": "^14.0.1",

--- a/javascript/packages/cli/package.json
+++ b/javascript/packages/cli/package.json
@@ -55,7 +55,7 @@
     "url": "https://github.com/paritytech/zombienet/issues"
   },
   "dependencies": {
-    "@zombienet/dsl-parser-wrapper": "^0.1.10",
+    "@zombienet/dsl-parser-wrapper": "^0.1.11",
     "@zombienet/orchestrator": "^0.0.95",
     "@zombienet/utils": "^0.0.25",
     "cli-progress": "^3.12.0",

--- a/javascript/packages/orchestrator/src/test-runner/assertions.ts
+++ b/javascript/packages/orchestrator/src/test-runner/assertions.ts
@@ -272,6 +272,8 @@ const CustomJs = ({
     const call_args = custom_args
       ? custom_args === ""
         ? []
+        : custom_args.charAt(0) === "{" // allow to pass a single quoted json
+        ? JSON.parse(custom_args)
         : custom_args.split(",")
       : [];
 

--- a/javascript/packages/orchestrator/src/test-runner/assertions.ts
+++ b/javascript/packages/orchestrator/src/test-runner/assertions.ts
@@ -273,8 +273,8 @@ const CustomJs = ({
       ? custom_args === ""
         ? []
         : custom_args.charAt(0) === "{" // allow to pass a single quoted json
-        ? JSON.parse(custom_args)
-        : custom_args.split(",")
+          ? JSON.parse(custom_args)
+          : custom_args.split(",")
       : [];
 
     let resolvedJsFilePath = path.resolve(configBasePath, file_path!);

--- a/tests/smoke/0001-custom-json.js
+++ b/tests/smoke/0001-custom-json.js
@@ -1,0 +1,20 @@
+async function run(nodeName, networkInfo, argObject) {
+    let err = false;
+    console.log(argObject);
+    if (argObject.account != "alice") {
+        console.log("JSON err: field name");
+        err = true;
+    }
+    if (argObject.nums[1] !== 1) {
+        console.log("JSON err: field nums");
+        err = true;
+    }
+    if (argObject.bool !== true) {
+        console.log("JSON err: field nums");
+        err = true;
+    }
+
+    if(err) throw new Error('JSON should be {"account": "alice", "nums": [0,1,2,3], "bool": true}');
+}
+
+module.exports = { run }

--- a/tests/smoke/0001-smoke.zndsl
+++ b/tests/smoke/0001-smoke.zndsl
@@ -29,6 +29,8 @@ alice: system event matches "paraId(.)*[0-9]+" within 20 seconds
 alice: js-script ./0001-custom.js return is greater than 1 within 200 seconds
 alice: js-script ./0001-custom.js within 200 seconds
 alice: js-script ./0001-custom.js with "alice" within 200 seconds
+# json argument
+alice: js-script ./0001-custom-json.js with '{"account": "alice", "nums": [0,1,2,3], "bool": true}' within 200 seconds
 alice: run ./0001-custom.sh within 200 seconds
 
 # Histogram assertions


### PR DESCRIPTION
Add support for passing a `json` as arg to `js-script`. Should be single quoted json like:

```
alice: js-script ./0001-custom-json.js with '{"account": "alice", "nums": [0,1,2,3], "bool": true}' within 200 seconds
```

And in the script you have access to the `Object` directly

```js
async function run(nodeName, networkInfo, argObject) {
    if (argObject.account != "alice") {
        console.log("JSON err: field name");
    }
```
cc: @bkontur 