### PR TITLE
Bump versions for release `v1.3.115`

### DIFF
--- a/flake-module.nix
+++ b/flake-module.nix
@@ -8,7 +8,7 @@
     ...
   }: let
     # this change on each change of dependencies, unfortunately this hash not yet automatically updated from SRI of package.lock
-    npmDepsHash = "sha256-UnHUaTZYwJ1DA9dltMz5bS8spSFUBfqS+IvjzGyHz/k=";
+    npmDepsHash = "sha256-t0DfM7tuSUJX34yDeTe43tjgA/+Pe9qIOynRItFX+F8=";
     ####
 
     # there is officia polkadot on nixpkgs, but it has no local rococo wasm to run

--- a/javascript/package-lock.json
+++ b/javascript/package-lock.json
@@ -6932,11 +6932,11 @@
     },
     "packages/cli": {
       "name": "@zombienet/cli",
-      "version": "1.3.114",
+      "version": "1.3.115",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@zombienet/dsl-parser-wrapper": "^0.1.11",
-        "@zombienet/orchestrator": "^0.0.95",
+        "@zombienet/orchestrator": "^0.0.96",
         "@zombienet/utils": "^0.0.25",
         "cli-progress": "^3.12.0",
         "commander": "^11.1.0",
@@ -6958,7 +6958,7 @@
     },
     "packages/orchestrator": {
       "name": "@zombienet/orchestrator",
-      "version": "0.0.95",
+      "version": "0.0.96",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@polkadot/api": "^14.0.1",

--- a/javascript/packages/cli/package.json
+++ b/javascript/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zombienet/cli",
-  "version": "1.3.114",
+  "version": "1.3.115",
   "description": "ZombieNet aim to be a testing framework for substrate based blockchains, providing a simple cli tool that allow users to spawn and test ephemeral Substrate based networks",
   "main": "dist/index.js",
   "scripts": {
@@ -56,7 +56,7 @@
   },
   "dependencies": {
     "@zombienet/dsl-parser-wrapper": "^0.1.11",
-    "@zombienet/orchestrator": "^0.0.95",
+    "@zombienet/orchestrator": "^0.0.96",
     "@zombienet/utils": "^0.0.25",
     "cli-progress": "^3.12.0",
     "commander": "^11.1.0",

--- a/javascript/packages/orchestrator/package.json
+++ b/javascript/packages/orchestrator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zombienet/orchestrator",
-  "version": "0.0.95",
+  "version": "0.0.96",
   "description": "ZombieNet aim to be a testing framework for substrate based blockchains, providing a simple cli tool that allow users to spawn and test ephemeral Substrate based networks",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Add:
  -  Support for passing a `json` as argument for `js-script` (#1902)
 
Fix:
  - Reorder wait cmd (#1904)
 