### PR TITLE
Add `darwin arm64` option to setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,7 +449,7 @@ Below can be found some of the projects that are currently using Zombienet as in
 - [Composable](https://github.com/ComposableFi/composable) via `nix run "composable#devnet-picasso"`
 - [Gossamer](https://github.com/ChainSafe/gossamer/issues/2843)
 - [Oak/Turing/Neumann](https://github.com/OAK-Foundation/OAK-blockchain/tree/master/zombienets)
-- [Hydradx](https://github.com/galacticcouncil/HydraDX-node/tree/master/rococo-local)
+- [Hydradx](https://github.com/galacticcouncil/HydraDX-node/tree/master/launch-configs/zombienet)
 - [InvArch](https://github.com/InvArch/InvArch-Node/blob/34a6e2216bc79c9bcee2f2f4c0cd8243fe4dfc93/zombienet/rococo-and-tinkernet+basilisk.toml)
 - [Mangata](https://github.com/mangata-finance/mangata-node/tree/develop/devops/zombienet)
 - [Manta/Phala](https://github.com/Manta-Network/manta-indexer/pull/30)

--- a/docs/src/projects.md
+++ b/docs/src/projects.md
@@ -14,7 +14,7 @@ Below can be found some of the projects that are currently using Zombienet as in
 - [Acurast](https://github.com/Acurast/acurast-substrate/blob/10c3160a297ae6c3092ee692e6d3b632896fca65/Makefile)
 - [Gossamer](https://github.com/ChainSafe/gossamer/issues/2843)
 - [Oak/Turing/Neumann](https://github.com/OAK-Foundation/OAK-blockchain/tree/master/zombienets)
-- [Hydradx](https://github.com/galacticcouncil/HydraDX-node/tree/master/rococo-local)
+- [Hydradx](https://github.com/galacticcouncil/HydraDX-node/tree/master/launch-configs/zombienet)
 - [InvArch](https://github.com/InvArch/InvArch-Node/blob/34a6e2216bc79c9bcee2f2f4c0cd8243fe4dfc93/zombienet/rococo-and-tinkernet+basilisk.toml)
 - [Mangata](https://github.com/mangata-finance/mangata-node/tree/develop/devops/zombienet)
 - [Manta/Phala](https://github.com/Manta-Network/manta-indexer/pull/30)

--- a/javascript/packages/cli/src/actions/setup.ts
+++ b/javascript/packages/cli/src/actions/setup.ts
@@ -200,7 +200,6 @@ const downloadBinaries = async (binaries: string[]): Promise<void> => {
     );
 
     for (const binary of binaries) {
-      console.log(options);
       promises.push(
         new Promise<void>(async (resolve) => {
           const result = options[binary];

--- a/scripts/ci/docker/zombienet_injected.Dockerfile
+++ b/scripts/ci/docker/zombienet_injected.Dockerfile
@@ -63,7 +63,7 @@ RUN mkdir -p /etc/zombie-net
 # USER nonroot
 
 # install rust
-ENV RUST_VERSION=1.80.0
+ENV RUST_VERSION=1.81.0
 RUN curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain $RUST_VERSION -y
 ENV PATH $PATH:/home/nonroot/.cargo/bin
 # install nextest

--- a/tests/scale-net/0001-scale-net.toml
+++ b/tests/scale-net/0001-scale-net.toml
@@ -9,12 +9,12 @@ chain = "rococo-local"
 
   [[relaychain.node_groups]]
   name = "a"
-  count = 1
+  count = 2
   {% include("./a-group.toml")%}
 
   [[relaychain.node_groups]]
   name = "b"
-  count = 1
+  count = 2
   {% include("./b-group.toml")%}
 
 {% for id in [100,200] %}


### PR DESCRIPTION
Fix #1933 
Now we have ARM (darwin) binaries in releases and we can use it for setup.

cc: @shawntabrizi 