### PR TITLE
fix(native): use rpc_port as default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Upload build artifacts
         if: ${{ matrix.node-version == '18.x' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ runner.os }}-build-${{ github.sha }}
           path: |
@@ -95,7 +95,7 @@ jobs:
   #       with:
   #         name: ${{ runner.os }}-build-${{ github.sha }}
   #         path: ./javascript/packages
-        
+
   #     - name: Install dependencies
   #       run: npm install --ignore-scripts
   #       working-directory: ./javascript

--- a/javascript/packages/orchestrator/src/cmdGenerator.ts
+++ b/javascript/packages/orchestrator/src/cmdGenerator.ts
@@ -101,9 +101,11 @@ export async function genCumulusCollatorCmd(
 
   if (validator) fullCmd.push(...["--collator"]);
 
+  // ports passed to the relaychain part of the collator binary
   const collatorPorts: PortsInterface = {
     "--port": 0,
     "--rpc-port": 0,
+    "--prometheus-port": 0,
   };
 
   if (nodeSetup.args.length > 0) {
@@ -341,10 +343,10 @@ const getPortFlagsByCliArgsVersion = (nodeSetup: Node) => {
     portFlags["--rpc-port"] = (nodeSetup.rpcPort || RPC_HTTP_PORT).toString();
     portFlags["--ws-port"] = (nodeSetup.wsPort || RPC_WS_PORT).toString();
   } else {
-    // use ws port as default
-    const portToUse = nodeSetup.wsPort
-      ? nodeSetup.wsPort
-      : nodeSetup.rpcPort || RPC_HTTP_PORT;
+    // use rpc_port as default (since ws_port was deprecated in https://github.com/paritytech/substrate/pull/13384)
+    const portToUse = nodeSetup.rpcPort
+      ? nodeSetup.rpcPort
+      : nodeSetup.wsPort || RPC_HTTP_PORT;
     portFlags["--rpc-port"] = portToUse.toString();
   }
 

--- a/javascript/packages/orchestrator/src/configGenerator.ts
+++ b/javascript/packages/orchestrator/src/configGenerator.ts
@@ -782,7 +782,9 @@ async function getPorts(provider: string, nodeSetup: any): Promise<any> {
   let ports = DEFAULT_PORTS;
 
   if (nodeSetup.ws_port) {
-    console.warn("'ws-port flag was deprecated in https://github.com/paritytech/substrate/pull/13384 (v0.9.43).\nIf you are using a recent version please use 'rpc_port' to set the port");
+    console.warn(
+      "'ws-port flag was deprecated in https://github.com/paritytech/substrate/pull/13384 (v0.9.43).\nIf you are using a recent version please use 'rpc_port' to set the port",
+    );
   }
 
   if (provider === "native") {

--- a/javascript/packages/orchestrator/src/configGenerator.ts
+++ b/javascript/packages/orchestrator/src/configGenerator.ts
@@ -781,6 +781,10 @@ function sanitizeArgs(
 async function getPorts(provider: string, nodeSetup: any): Promise<any> {
   let ports = DEFAULT_PORTS;
 
+  if (nodeSetup.ws_port) {
+    console.warn("'ws-port flag was deprecated in https://github.com/paritytech/substrate/pull/13384 (v0.9.43).\nIf you are using a recent version please use 'rpc_port' to set the port");
+  }
+
   if (provider === "native") {
     ports = {
       p2pPort: nodeSetup.p2p_port || (await getRandomPort()),

--- a/javascript/packages/orchestrator/src/spawner.ts
+++ b/javascript/packages/orchestrator/src/spawner.ts
@@ -12,6 +12,7 @@ import {
   LOCALHOST,
   METRICS_URI_PATTERN,
   PROMETHEUS_PORT,
+  RPC_HTTP_PORT,
   RPC_WS_PORT,
   WS_URI_PATTERN,
 } from "./constants";
@@ -121,7 +122,7 @@ export const spawnNode = async (
 
   let networkNode: NetworkNode;
 
-  const endpointPort = RPC_WS_PORT;
+  const endpointPort = node.substrateCliArgsVersion == 0 ? RPC_WS_PORT : RPC_HTTP_PORT;
   if (opts.inCI) {
     // UPDATE: 04-10-2024 Since we have several reports of failures related to
     // can't access metrics by dns, we switch back to use the pod ip.

--- a/javascript/packages/orchestrator/src/spawner.ts
+++ b/javascript/packages/orchestrator/src/spawner.ts
@@ -122,7 +122,8 @@ export const spawnNode = async (
 
   let networkNode: NetworkNode;
 
-  const endpointPort = node.substrateCliArgsVersion == 0 ? RPC_WS_PORT : RPC_HTTP_PORT;
+  const endpointPort =
+    node.substrateCliArgsVersion == 0 ? RPC_WS_PORT : RPC_HTTP_PORT;
   if (opts.inCI) {
     // UPDATE: 04-10-2024 Since we have several reports of failures related to
     // can't access metrics by dns, we switch back to use the pod ip.


### PR DESCRIPTION
Fix #1219 

__NOTE__: This will use `rpc_port` as default port for for the ws connect uri.

cc: @iulianbarbu 