### PR TITLE
Fix moonbeam chain spec customizations

### DIFF
--- a/javascript/packages/orchestrator/src/chain-decorators/moonbeam.ts
+++ b/javascript/packages/orchestrator/src/chain-decorators/moonbeam.ts
@@ -141,7 +141,9 @@ async function addParaCustom(specPath: string, node: Node) {
 
   const expectedBalance = stakingBond + reservedBalance;
   if (collatorBalance) {
-    collatorBalance[1] = expectedBalance;
+    if (collatorBalance[1] < expectedBalance) {
+      collatorBalance[1] = expectedBalance;
+    }
   } else {
     runtimeConfig.balances.balances.push([
       eth_account.address,

--- a/javascript/packages/orchestrator/src/chain-decorators/moonbeam.ts
+++ b/javascript/packages/orchestrator/src/chain-decorators/moonbeam.ts
@@ -126,37 +126,30 @@ async function addParaCustom(specPath: string, node: Node) {
   const chainSpec = readAndParseChainSpec(specPath);
   const runtimeConfig = getRuntimeConfig(chainSpec);
 
-  // parachainStaking
   if (!runtimeConfig?.parachainStaking) return;
 
   const { eth_account } = node.accounts;
 
-  const stakingBond = paraStakingBond || BigInt("1000000000000000000000");
-  const reservedBalance = BigInt("100000000000000000000");
+  const stakingBond = paraStakingBond || BigInt("2000000000000000000000000");
+  const reservedBalance = BigInt("100000000000000000000000");
 
   // Ensure collator account has enough balance to bond and add candidate
-  const node_index = runtimeConfig.balances.balances.findIndex(
-    (item: [string, BigInt]) => {
-      return item[0] === eth_account.address.toLowerCase();
-    },
+  const collatorBalance = runtimeConfig.balances.balances.find(
+    ([address]: [string, BigInt]) =>
+      address === eth_account.address.toLowerCase(),
   );
 
-  if (node_index > -1) runtimeConfig.balances.balances.splice(node_index, 1);
+  const expectedBalance = stakingBond + reservedBalance;
+  if (collatorBalance) {
+    collatorBalance[1] = expectedBalance;
+  } else {
+    runtimeConfig.balances.balances.push([
+      eth_account.address,
+      expectedBalance,
+    ]);
+  }
 
-  runtimeConfig.balances.balances.push([
-    eth_account.address,
-    stakingBond + reservedBalance,
-  ]);
-
-  const candidate_index = runtimeConfig.balances.balances.findIndex(
-    (item: [string, BigInt]) => {
-      return item[0] === eth_account.address.toLowerCase();
-    },
-  );
-
-  if (candidate_index > -1)
-    runtimeConfig.balances.balances.splice(candidate_index, 1);
-
+  // Add collator account as candidate
   runtimeConfig.parachainStaking.candidates.push([
     eth_account.address,
     stakingBond,


### PR DESCRIPTION
The moonbeam customizations were not correct when using `moonbeam-local` chain specification. The reason is that `moonbeam` uses a [SUPPLY_FACTOR](https://github.com/moonbeam-foundation/moonbeam/blob/4c9dc6d12d82108987d15d29f49f29af034e2398/runtime/moonbeam/src/lib.rs#L138) of `100`, while `moonbase` and `moonriver` have a supply factor of `1`. This was causing the `reservedBalance` to be incorrect.

The fix included in this PR, increases `stakingBond` and `reservedBalance` default values to a reasonable amount and overrides the balance of the collator if it is not enough to cover the staking bond and the authoring deposit.