### PR TITLE
ci: use gcp registry for integration tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -14,17 +14,20 @@ concurrency:
 permissions: {}
 
 env:
-  IMAGE_NAME: paritypr/zombienet
+  IMAGE_NAME: europe-docker.pkg.dev/parity-ci-2024/temp-images/zombienet
   VERSION: ${{ github.sha }}
   RUN_IN_CONTAINER: 1
   FF_DISABLE_UMASK_FOR_DOCKER_EXECUTOR: 1
   GHA_CLUSTER_SERVER_ADDR: "https://kubernetes.default:443"
 
 jobs:
-  build_push_image:
-    name: Build and Push Docker image to Docker Hub
+  build_push_image_master:
+    name: Build and Push Docker image to Docker Hub on main branch
     runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     timeout-minutes: 30
+    env:
+      IMAGE_NAME: paritypr/zombienet
     steps:
       - name: Check out the repo
         uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v.4.2.0
@@ -52,6 +55,37 @@ jobs:
           tags: |
             ${{ env.IMAGE_NAME }}:${{ env.VERSION }}
             ${{ env.IMAGE_NAME }}:latest
+  build_push_image:
+    name: Build and Push Docker image to GCP
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v.4.2.0
+
+      - name: npm build
+        run: |
+          cd javascript
+          npm install
+          npm dedupe
+          npm run clean
+          npm run build
+
+      - name: "Set up Cloud SDK"
+        uses: "google-github-actions/setup-gcloud@v2"
+      - name: "gcloud info"
+        run: "gcloud info"
+      - name: "Auth in gcloud registry"
+        run: "gcloud auth configure-docker europe-docker.pkg.dev --quiet"
+
+      - name: build
+        run: |
+          export DOCKER_IMAGES_VERSION=${{ env.VERSION }}
+          docker build \
+            -t ${{ env.IMAGE_NAME }}:${{ env.VERSION }} \
+            -f ./scripts/ci/docker/zombienet_injected.Dockerfile \
+            .
+          docker push "${{ inputs.image-name }}:$DOCKER_IMAGES_VERSION"
 
   set-variables:
     name: Set variables


### PR DESCRIPTION
PR changes integration tests workflow so it pushes images to GCP registry. I also decided to keep docker image build for master but it will push to docker hub.

cc https://github.com/paritytech/ci_cd/issues/1106