### PR TITLE
Dropping bucket metrics in podMonitor

### DIFF
--- a/javascript/packages/orchestrator/static-configs/pod-monitor.yaml
+++ b/javascript/packages/orchestrator/static-configs/pod-monitor.yaml
@@ -11,7 +11,7 @@ spec:
       port: prometheus
       metricRelabelings:
         - sourceLabels: [__name__]
-          regex: ".*_bucket"
+          regex: '^(?!polkadot_pvf_.*_bucket$).+_bucket$'
           action: drop
   namespaceSelector:
       matchNames:

--- a/javascript/packages/orchestrator/static-configs/pod-monitor.yaml
+++ b/javascript/packages/orchestrator/static-configs/pod-monitor.yaml
@@ -9,6 +9,10 @@ spec:
     - interval: 5s
       path: /metrics
       port: prometheus
+      metricRelabelings:
+        - sourceLabels: [__name__]
+          regex: ".*_bucket"
+          action: drop
   namespaceSelector:
       matchNames:
       - "{{namespace}}"


### PR DESCRIPTION
Buckets are generated by the polkadot-sdk, but I don't think it is beneficial with zombienet's use case since it is expected to be short-lived. A single bucket metric (e.g, substrate_tasks_polling_duration_bucket) creates around 6090 series for a single zombienet namespace, and there's a lot of metrics aside from substrate_tasks_polling_duration_bucket. Dropping the histogram (bucket) metrics are beneficial since we can still refer to other metrics (e.g, _sum, _count, _total).