### PR TITLE
docs: add Linux binary installation steps to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,11 +63,11 @@ Then you should be able to access the binary:
 
 After you have downloaded `zombienet-linux-x64` (or the appropriate binary for your architecture), you will need to:
 
-- Move the binary to your working directory.**
+- Move the binary to your working directory.
 
-- Rename the binary to just `zombienet`** without any `linux-<version>` extension for convenience.
+- Rename the binary to just `zombienet` without any `linux-<version>` extension for convenience.
 
-- Enable the binary to be executable:**
+- Enable the binary to be executable:
    ```bash
    chmod +x ./zombienet
    ```

--- a/README.md
+++ b/README.md
@@ -59,6 +59,25 @@ Then you should be able to access the binary:
 ./zombienet help
 ```
 
+### 🐧 Using Binaries on Linux
+
+After you have downloaded `zombienet-linux-x64` (or the appropriate binary for your architecture), you will need to:
+
+- Move the binary to your working directory.**
+
+- Rename the binary to just `zombienet`** without any `linux-<version>` extension for convenience.
+
+- Enable the binary to be executable:**
+   ```bash
+   chmod +x ./zombienet
+   ```
+   
+Then you should be able to access the binary:
+
+```bash
+./zombienet help
+```
+
 ### Install from NPM
 
 If you have `Node.js`, you can install `zombienet` locally via NPM:


### PR DESCRIPTION
This PR adds Linux installation instructions to the README under the Usage section