### PR TITLE
fix cargo clippy warning

### DIFF
--- a/crates/parser/src/lib.rs
+++ b/crates/parser/src/lib.rs
@@ -181,7 +181,7 @@ fn parse_custom_script_rule(
     let node_name = parse_name(get_pair(&mut pairs, "name")?)?;
     let file_path_str = get_pair(&mut pairs, "file_path")?.as_str();
     let file_path: PathBuf = file_path_str
-        .try_into()
+        .into()
         .map_err(|_| errors::ParserError::ParseError(format!("Invalid path: {file_path_str}")))?;
 
     let mut args: Option<String> = None;


### PR DESCRIPTION
`cargo clippy` reports the following notice:

```
warning: use of a fallible conversion when an infallible one could be used
   --> crates/parser/src/lib.rs:184:10
    |
184 |         .try_into()
    |          ^^^^^^^^ help: use: `into`
    |
    = note: converting `&str` to `PathBuf` cannot fail
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_fallible_conversions
    = note: `#[warn(clippy::unnecessary_fallible_conversions)]` on by default
```

This pr resolves the issue.