### PR TITLE
align polkadot js dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 19.x, 20.x, 22.x]
+        node-version: [22.x, 24.x, 25.x]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 19.x, 20.x]
+        node-version: [18.x, 19.x, 20.x, 22.x]
 
     steps:
       - uses: actions/checkout@v4
@@ -30,7 +30,7 @@ jobs:
         working-directory: "./javascript"
 
       - name: Upload build artifacts
-        if: ${{ matrix.node-version == '18.x' }}
+        if: ${{ matrix.node-version == '22.x' }}
         uses: actions/upload-artifact@v4
         with:
           name: ${{ runner.os }}-build-${{ github.sha }}
@@ -44,18 +44,18 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-         
+
       - name: Install fmt and clippy
         run: |
           rustup component add rustfmt
           rustup component add clippy
-          
+
       - name: Run cargo fmt
         run: cargo fmt --all -- --check
-        
+
       - name: Run clippy
         run: cargo clippy --all-features -- -D warnings
-        
+
       - name: Build
         run: cargo build
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -71,7 +71,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
 
       - name: npm build
         run: |

--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -13,7 +13,7 @@ jobs:
         working-directory: "./javascript"
       - uses: actions/setup-node@v4
         with:
-          node-version: "18.x"
+          node-version: "22.x"
       - name: Build NPM Package
         run: npm run build
         working-directory: "./javascript"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,7 +35,7 @@ jobs:
       - name: setup node
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '22'
       - run: npm install
         working-directory: "./javascript"
       - run: npm dedupe
@@ -76,7 +76,7 @@ jobs:
       - name: setup node
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '22'
       - run: npm install && npm update
         working-directory: "./javascript"
       - run: npm run build

--- a/.github/workflows/setup-tests.yml
+++ b/.github/workflows/setup-tests.yml
@@ -56,7 +56,7 @@ jobs:
           - run: |
               ls -l
               mv releases.json /tmp
-          - run: npm install && npm update
+          - run: npm install
             working-directory: "./javascript"
           - run: npm run build
             working-directory: "./javascript"

--- a/.github/workflows/setup-tests.yml
+++ b/.github/workflows/setup-tests.yml
@@ -48,7 +48,7 @@ jobs:
           - name: setup node
             uses: actions/setup-node@v4
             with:
-              node-version: '20'
+              node-version: '22'
           - name: Download request file
             uses: actions/download-artifact@v4.1.8
             with:

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -8,7 +8,7 @@
     ...
   }: let
     # this change on each change of dependencies, unfortunately this hash not yet automatically updated from SRI of package.lock
-    npmDepsHash = "sha256-H9ZRFUgNyrUAxlwCzLabLTnxbpVMtdrNfzFwP284C3M=";
+    npmDepsHash = "sha256-2O+Q8K/Ua32RVxPfUbO5U/36r3Q+GB/uj/2dbyiVYCE=";
     ####
 
     # there is officia polkadot on nixpkgs, but it has no local rococo wasm to run

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -8,7 +8,7 @@
     ...
   }: let
     # this change on each change of dependencies, unfortunately this hash not yet automatically updated from SRI of package.lock
-    npmDepsHash = "sha256-2O+Q8K/Ua32RVxPfUbO5U/36r3Q+GB/uj/2dbyiVYCE=";
+    npmDepsHash = "sha256-5Ch63Uqkp8BIo2aYNsm4G5Gi624sTnZalPehZUZiFoY=";
     ####
 
     # there is officia polkadot on nixpkgs, but it has no local rococo wasm to run

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -247,6 +247,8 @@
           makeCacheWritable = true;
         };
 
+        zombienet = default;
+
         update = pkgs.writeShellApplication {
           name = "update";
           runtimeInputs = [pkgs.prefetch-npm-deps];

--- a/flake.nix
+++ b/flake.nix
@@ -21,7 +21,7 @@
         inputs.process-compose.flakeModule
         ./flake-module.nix
       ];
-      systems = ["x86_64-linux" "aarch64-linux" "aarch64-darwin" "x86_64-darwin"];
+      systems = ["x86_64-linux" "aarch64-linux" "aarch64-darwin"];
     };
   in
     outputs

--- a/javascript/package-lock.json
+++ b/javascript/package-lock.json
@@ -7430,12 +7430,30 @@
       },
       "devDependencies": {
         "@types/cli-progress": "^3.11.5",
+        "@types/node": "^25.5.2",
         "@types/nunjucks": "^3.2.6",
         "pkg": "~5.8.1"
       },
       "engines": {
         "node": ">=18"
       }
+    },
+    "packages/cli/node_modules/@types/node": {
+      "version": "25.5.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.2.tgz",
+      "integrity": "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "packages/cli/node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
     },
     "packages/orchestrator": {
       "name": "@zombienet/orchestrator",
@@ -7467,10 +7485,21 @@
         "@types/fs-extra": "^11.0.4",
         "@types/jsdom": "^21.1.6",
         "@types/minimatch": "^5.1.2",
-        "@types/mocha": "^10.0.6"
+        "@types/mocha": "^10.0.6",
+        "@types/node": "^25.5.2"
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "packages/orchestrator/node_modules/@types/node": {
+      "version": "25.5.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.2.tgz",
+      "integrity": "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
       }
     },
     "packages/orchestrator/node_modules/minimatch": {
@@ -7486,6 +7515,13 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "packages/orchestrator/node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
     },
     "packages/utils": {
       "name": "@zombienet/utils",
@@ -7503,6 +7539,7 @@
         "@types/chai": "^4.3.11",
         "@types/deep-equal-in-any-order": "^1.0.3",
         "@types/mocha": "^10.0.6",
+        "@types/node": "^25.5.2",
         "@types/nunjucks": "^3.2.6",
         "@types/sinon": "^17.0.3",
         "chai": "^4.3.10",
@@ -7516,6 +7553,23 @@
     },
     "packages/utils/github.com/pepoviola/toml-node": {
       "extraneous": true
+    },
+    "packages/utils/node_modules/@types/node": {
+      "version": "25.5.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.2.tgz",
+      "integrity": "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "packages/utils/node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
     }
   }
 }

--- a/javascript/package-lock.json
+++ b/javascript/package-lock.json
@@ -687,52 +687,30 @@
       }
     },
     "node_modules/@polkadot/keyring": {
-      "version": "13.3.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/keyring/-/keyring-13.3.1.tgz",
-      "integrity": "sha512-PT3uG9MqciPyoEz/f23RRMSlht77fo1hZaA1Vbcs1Rz7h7qFC0+7jFI9Ak30EJh9V0I2YugfzqAe3NjjyDxlvw==",
-      "dependencies": {
-        "@polkadot/util": "13.3.1",
-        "@polkadot/util-crypto": "13.3.1",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@polkadot/util": "13.3.1",
-        "@polkadot/util-crypto": "13.3.1"
-      }
-    },
-    "node_modules/@polkadot/keyring/node_modules/@polkadot/util-crypto": {
-      "version": "13.3.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-13.3.1.tgz",
-      "integrity": "sha512-FU6yf3IY++DKlf0eqO9/obe2y1zuZ5rbqRs75fyOME/5VXio1fA3GIpW7aFphyneFRd78G8QLh8kn0oIwBGMNg==",
+      "version": "13.5.9",
+      "resolved": "https://registry.npmjs.org/@polkadot/keyring/-/keyring-13.5.9.tgz",
+      "integrity": "sha512-bMCpHDN7U8ytxawjBZ89/he5s3AmEZuOdkM/ABcorh/flXNPfyghjFK27Gy4OKoFxX52yJ2sTHR4NxM87GuFXQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@noble/curves": "^1.3.0",
-        "@noble/hashes": "^1.3.3",
-        "@polkadot/networks": "13.3.1",
-        "@polkadot/util": "13.3.1",
-        "@polkadot/wasm-crypto": "^7.4.1",
-        "@polkadot/wasm-util": "^7.4.1",
-        "@polkadot/x-bigint": "13.3.1",
-        "@polkadot/x-randomvalues": "13.3.1",
-        "@scure/base": "^1.1.7",
+        "@polkadot/util": "13.5.9",
+        "@polkadot/util-crypto": "13.5.9",
         "tslib": "^2.8.0"
       },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
-        "@polkadot/util": "13.3.1"
+        "@polkadot/util": "13.5.9",
+        "@polkadot/util-crypto": "13.5.9"
       }
     },
     "node_modules/@polkadot/networks": {
-      "version": "13.3.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/networks/-/networks-13.3.1.tgz",
-      "integrity": "sha512-g/0OmCMUrbbW4RQ/xajTYd2SMJvFKY4kmMvpxtNN57hWQpY7c5oDXSz57jGH2uwvcBWeDfaNokcS+9hJL1RBcA==",
+      "version": "13.5.9",
+      "resolved": "https://registry.npmjs.org/@polkadot/networks/-/networks-13.5.9.tgz",
+      "integrity": "sha512-nmKUKJjiLgcih0MkdlJNMnhEYdwEml2rv/h59ll2+rAvpsVWMTLCb6Cq6q7UC44+8kiWK2UUJMkFU+3PFFxndA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@polkadot/util": "13.3.1",
+        "@polkadot/util": "13.5.9",
         "@substrate/ss58-registry": "^1.51.0",
         "tslib": "^2.8.0"
       },
@@ -883,14 +861,15 @@
       }
     },
     "node_modules/@polkadot/util": {
-      "version": "13.3.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-13.3.1.tgz",
-      "integrity": "sha512-5crLP/rUZOJzuo/W8t73J8PxpibJ5vrxY57rR6V+mIpCZd1ORiw0wxeHcV5F9Adpn7yJyuGBwxPbueNR5Rr1Zw==",
+      "version": "13.5.9",
+      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-13.5.9.tgz",
+      "integrity": "sha512-pIK3XYXo7DKeFRkEBNYhf3GbCHg6dKQisSvdzZwuyzA6m7YxQq4DFw4IE464ve4Z7WsJFt3a6C9uII36hl9EWw==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@polkadot/x-bigint": "13.3.1",
-        "@polkadot/x-global": "13.3.1",
-        "@polkadot/x-textdecoder": "13.3.1",
-        "@polkadot/x-textencoder": "13.3.1",
+        "@polkadot/x-bigint": "13.5.9",
+        "@polkadot/x-global": "13.5.9",
+        "@polkadot/x-textdecoder": "13.5.9",
+        "@polkadot/x-textencoder": "13.5.9",
         "@types/bn.js": "^5.1.6",
         "bn.js": "^5.2.1",
         "tslib": "^2.8.0"
@@ -900,19 +879,19 @@
       }
     },
     "node_modules/@polkadot/util-crypto": {
-      "version": "13.5.7",
-      "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-13.5.7.tgz",
-      "integrity": "sha512-SNzfAmtSSfUnQesrGLxc1RDg1arsvFSsAkH0xulffByqJfLugB3rZWJXIKqKNfcRZtomsMMURPeW7lfpAomSug==",
+      "version": "13.5.9",
+      "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-13.5.9.tgz",
+      "integrity": "sha512-foUesMhxkTk8CZ0/XEcfvHk6I0O+aICqqVJllhOpyp/ZVnrTBKBf59T6RpsXx2pCtBlMsLRvg/6Mw7RND1HqDg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/curves": "^1.3.0",
         "@noble/hashes": "^1.3.3",
-        "@polkadot/networks": "13.5.7",
-        "@polkadot/util": "13.5.7",
-        "@polkadot/wasm-crypto": "^7.5.1",
-        "@polkadot/wasm-util": "^7.5.1",
-        "@polkadot/x-bigint": "13.5.7",
-        "@polkadot/x-randomvalues": "13.5.7",
+        "@polkadot/networks": "13.5.9",
+        "@polkadot/util": "13.5.9",
+        "@polkadot/wasm-crypto": "^7.5.3",
+        "@polkadot/wasm-util": "^7.5.3",
+        "@polkadot/x-bigint": "13.5.9",
+        "@polkadot/x-randomvalues": "13.5.9",
         "@scure/base": "^1.1.7",
         "tslib": "^2.8.0"
       },
@@ -920,103 +899,15 @@
         "node": ">=18"
       },
       "peerDependencies": {
-        "@polkadot/util": "13.5.7"
+        "@polkadot/util": "13.5.9"
       }
     },
-    "node_modules/@polkadot/util-crypto/node_modules/@polkadot/networks": {
-      "version": "13.5.7",
-      "resolved": "https://registry.npmjs.org/@polkadot/networks/-/networks-13.5.7.tgz",
-      "integrity": "sha512-RdQcgaPy68NRSI7UTBdxr1aw66MXVdbpGhpWQpLf3/7puUdwkem6KxqFNnC9/kJSXRlyYGeYHN9Hsf4+CTWBSQ==",
+    "node_modules/@polkadot/util/node_modules/@polkadot/x-global": {
+      "version": "13.5.9",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-13.5.9.tgz",
+      "integrity": "sha512-zSRWvELHd3Q+bFkkI1h2cWIqLo1ETm+MxkNXLec3lB56iyq/MjWBxfXnAFFYFayvlEVneo7CLHcp+YTFd9aVSA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@polkadot/util": "13.5.7",
-        "@substrate/ss58-registry": "^1.51.0",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@polkadot/util-crypto/node_modules/@polkadot/util": {
-      "version": "13.5.7",
-      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-13.5.7.tgz",
-      "integrity": "sha512-5Rhp6/FDI55iCJcGd/9bMQaF0E26OE+uZwz68JuRW75DW8v7zsN3bnjnVqk3KO/c4u5EgLSqbhXPuyW24BP1+Q==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-bigint": "13.5.7",
-        "@polkadot/x-global": "13.5.7",
-        "@polkadot/x-textdecoder": "13.5.7",
-        "@polkadot/x-textencoder": "13.5.7",
-        "@types/bn.js": "^5.1.6",
-        "bn.js": "^5.2.1",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@polkadot/util-crypto/node_modules/@polkadot/x-bigint": {
-      "version": "13.5.7",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-13.5.7.tgz",
-      "integrity": "sha512-NbN4EPbMBhjOXoWj0BVcT49/obzusFWPKbSyBxbZi8ITBaIIgpncgcCfXY4rII6Fqh74khx9jdevWge/6ycepQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "13.5.7",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@polkadot/util-crypto/node_modules/@polkadot/x-global": {
-      "version": "13.5.7",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-13.5.7.tgz",
-      "integrity": "sha512-TkBxLfeKtj0laCzXp2lvRhwSIeXSxIu7LAWpfAUW4SYNFQvtgIS0x0Bq70CUW3lcy0wqTrSG2cqzfnbomB0Djw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@polkadot/util-crypto/node_modules/@polkadot/x-randomvalues": {
-      "version": "13.5.7",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-13.5.7.tgz",
-      "integrity": "sha512-NEElpdu+Wqlr6USoh3abQfe0MaWlFlynPiqkA0/SJjK+0V0UOw0CyPwPgGrGa71/ju+1bsnu/ySshXqCR8HXTw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "13.5.7",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@polkadot/util": "13.5.7",
-        "@polkadot/wasm-util": "*"
-      }
-    },
-    "node_modules/@polkadot/util-crypto/node_modules/@polkadot/x-textdecoder": {
-      "version": "13.5.7",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-13.5.7.tgz",
-      "integrity": "sha512-wjSj+T2pBA1uW9dDYriZMAv4WgXl5zcWblxwOsZd3V/qxifMSlSLAy0WeC+08DD6TXGQYCOU0uOALsDivkUDZA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "13.5.7",
-        "tslib": "^2.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@polkadot/util-crypto/node_modules/@polkadot/x-textencoder": {
-      "version": "13.5.7",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-13.5.7.tgz",
-      "integrity": "sha512-h6RsGUY8ZZrfqsbojD1VqTqmXcojDSfbXQHhVcAWqgceeh9JOOw8Q6yzhv+KpPelqKq/map3bobJaebQ8QNTMw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@polkadot/x-global": "13.5.7",
         "tslib": "^2.8.0"
       },
       "engines": {
@@ -1024,12 +915,12 @@
       }
     },
     "node_modules/@polkadot/wasm-bridge": {
-      "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/wasm-bridge/-/wasm-bridge-7.5.1.tgz",
-      "integrity": "sha512-E+N3CSnX3YaXpAmfIQ+4bTyiAqJQKvVcMaXjkuL8Tp2zYffClWLG5e+RY15Uh+EWfUl9If4y6cLZi3D5NcpAGQ==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/wasm-bridge/-/wasm-bridge-7.5.4.tgz",
+      "integrity": "sha512-6xaJVvoZbnbgpQYXNw9OHVNWjXmtcoPcWh7hlwx3NpfiLkkjljj99YS+XGZQlq7ks2fVCg7FbfknkNb8PldDaA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@polkadot/wasm-util": "7.5.1",
+        "@polkadot/wasm-util": "7.5.4",
         "tslib": "^2.7.0"
       },
       "engines": {
@@ -1041,16 +932,16 @@
       }
     },
     "node_modules/@polkadot/wasm-crypto": {
-      "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto/-/wasm-crypto-7.5.1.tgz",
-      "integrity": "sha512-acjt4VJ3w19v7b/SIPsV/5k9s6JsragHKPnwoZ0KTfBvAFXwzz80jUzVGxA06SKHacfCUe7vBRlz7M5oRby1Pw==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto/-/wasm-crypto-7.5.4.tgz",
+      "integrity": "sha512-1seyClxa7Jd7kQjfnCzTTTfYhTa/KUTDUaD3DMHBk5Q4ZUN1D1unJgX+v1aUeXSPxmzocdZETPJJRZjhVOqg9g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@polkadot/wasm-bridge": "7.5.1",
-        "@polkadot/wasm-crypto-asmjs": "7.5.1",
-        "@polkadot/wasm-crypto-init": "7.5.1",
-        "@polkadot/wasm-crypto-wasm": "7.5.1",
-        "@polkadot/wasm-util": "7.5.1",
+        "@polkadot/wasm-bridge": "7.5.4",
+        "@polkadot/wasm-crypto-asmjs": "7.5.4",
+        "@polkadot/wasm-crypto-init": "7.5.4",
+        "@polkadot/wasm-crypto-wasm": "7.5.4",
+        "@polkadot/wasm-util": "7.5.4",
         "tslib": "^2.7.0"
       },
       "engines": {
@@ -1062,9 +953,9 @@
       }
     },
     "node_modules/@polkadot/wasm-crypto-asmjs": {
-      "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-asmjs/-/wasm-crypto-asmjs-7.5.1.tgz",
-      "integrity": "sha512-jAg7Uusk+xeHQ+QHEH4c/N3b1kEGBqZb51cWe+yM61kKpQwVGZhNdlWetW6U23t/BMyZArIWMsZqmK/Ij0PHog==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-asmjs/-/wasm-crypto-asmjs-7.5.4.tgz",
+      "integrity": "sha512-ZYwxQHAJ8pPt6kYk9XFmyuFuSS+yirJLonvP+DYbxOrARRUHfN4nzp4zcZNXUuaFhpbDobDSFn6gYzye6BUotA==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.7.0"
@@ -1077,15 +968,15 @@
       }
     },
     "node_modules/@polkadot/wasm-crypto-init": {
-      "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-init/-/wasm-crypto-init-7.5.1.tgz",
-      "integrity": "sha512-Obu4ZEo5jYO6sN31eqCNOXo88rPVkP9TrUOyynuFCnXnXr8V/HlmY/YkAd9F87chZnkTJRlzak17kIWr+i7w3A==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-init/-/wasm-crypto-init-7.5.4.tgz",
+      "integrity": "sha512-U6s4Eo2rHs2n1iR01vTz/sOQ7eOnRPjaCsGWhPV+ZC/20hkVzwPAhiizu/IqMEol4tO2yiSheD4D6bn0KxUJhg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@polkadot/wasm-bridge": "7.5.1",
-        "@polkadot/wasm-crypto-asmjs": "7.5.1",
-        "@polkadot/wasm-crypto-wasm": "7.5.1",
-        "@polkadot/wasm-util": "7.5.1",
+        "@polkadot/wasm-bridge": "7.5.4",
+        "@polkadot/wasm-crypto-asmjs": "7.5.4",
+        "@polkadot/wasm-crypto-wasm": "7.5.4",
+        "@polkadot/wasm-util": "7.5.4",
         "tslib": "^2.7.0"
       },
       "engines": {
@@ -1097,12 +988,12 @@
       }
     },
     "node_modules/@polkadot/wasm-crypto-wasm": {
-      "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-wasm/-/wasm-crypto-wasm-7.5.1.tgz",
-      "integrity": "sha512-S2yQSGbOGTcaV6UdipFVyEGanJvG6uD6Tg7XubxpiGbNAblsyYKeFcxyH1qCosk/4qf+GIUwlOL4ydhosZflqg==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-wasm/-/wasm-crypto-wasm-7.5.4.tgz",
+      "integrity": "sha512-PsHgLsVTu43eprwSvUGnxybtOEuHPES6AbApcs7y5ZbM2PiDMzYbAjNul098xJK/CPtrxZ0ePDFnaQBmIJyTFw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@polkadot/wasm-util": "7.5.1",
+        "@polkadot/wasm-util": "7.5.4",
         "tslib": "^2.7.0"
       },
       "engines": {
@@ -1113,9 +1004,9 @@
       }
     },
     "node_modules/@polkadot/wasm-util": {
-      "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/wasm-util/-/wasm-util-7.5.1.tgz",
-      "integrity": "sha512-sbvu71isFhPXpvMVX+EkRnUg/+54Tx7Sf9BEMqxxoPj7cG1I/MKeDEwbQz6MaU4gm7xJqvEWCAemLFcXfHQ/2A==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/wasm-util/-/wasm-util-7.5.4.tgz",
+      "integrity": "sha512-hqPpfhCpRAqCIn/CYbBluhh0TXmwkJnDRjxrU9Bnqtw9nMNa97D8JuOjdd2pi0rxm+eeLQ/f1rQMp71RMM9t4w==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.7.0"
@@ -1128,11 +1019,24 @@
       }
     },
     "node_modules/@polkadot/x-bigint": {
-      "version": "13.3.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-13.3.1.tgz",
-      "integrity": "sha512-ewc708a7LUdrT92v9DsSAIbcJQBn3aR9/LavF/iyMOq5lZJyPXDSjAnskfMs818R3RLCrKVKfs+aKkxt2eqo8g==",
+      "version": "13.5.9",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-13.5.9.tgz",
+      "integrity": "sha512-JVW6vw3e8fkcRyN9eoc6JIl63MRxNQCP/tuLdHWZts1tcAYao0hpWUzteqJY93AgvmQ91KPsC1Kf3iuuZCi74g==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@polkadot/x-global": "13.3.1",
+        "@polkadot/x-global": "13.5.9",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/x-bigint/node_modules/@polkadot/x-global": {
+      "version": "13.5.9",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-13.5.9.tgz",
+      "integrity": "sha512-zSRWvELHd3Q+bFkkI1h2cWIqLo1ETm+MxkNXLec3lB56iyq/MjWBxfXnAFFYFayvlEVneo7CLHcp+YTFd9aVSA==",
+      "license": "Apache-2.0",
+      "dependencies": {
         "tslib": "^2.8.0"
       },
       "engines": {
@@ -1164,28 +1068,53 @@
       }
     },
     "node_modules/@polkadot/x-randomvalues": {
-      "version": "13.3.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-13.3.1.tgz",
-      "integrity": "sha512-GIb0au3vIX2U/DRH0PRckM+1I4EIbU8PLX1roGJgN1MAYKWiylJTKPVoBMafMM87o8qauOevJ46uYB/qlfbiWg==",
+      "version": "13.5.9",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-13.5.9.tgz",
+      "integrity": "sha512-Uuuz3oubf1JCCK97fsnVUnHvk4BGp/W91mQWJlgl5TIOUSSTIRr+lb5GurCfl4kgnQq53Zi5fJV+qR9YumbnZw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@polkadot/x-global": "13.3.1",
+        "@polkadot/x-global": "13.5.9",
         "tslib": "^2.8.0"
       },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
-        "@polkadot/util": "13.3.1",
+        "@polkadot/util": "13.5.9",
         "@polkadot/wasm-util": "*"
       }
     },
-    "node_modules/@polkadot/x-textdecoder": {
-      "version": "13.3.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-13.3.1.tgz",
-      "integrity": "sha512-g2R9O1p0ZsNDhZ3uEBZh6fQaVLlo3yFr0YNqt15v7e9lBI4APvTJ202EINlo2jB5lz/R438/BdjEA3AL+0zUtQ==",
+    "node_modules/@polkadot/x-randomvalues/node_modules/@polkadot/x-global": {
+      "version": "13.5.9",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-13.5.9.tgz",
+      "integrity": "sha512-zSRWvELHd3Q+bFkkI1h2cWIqLo1ETm+MxkNXLec3lB56iyq/MjWBxfXnAFFYFayvlEVneo7CLHcp+YTFd9aVSA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@polkadot/x-global": "13.3.1",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/x-textdecoder": {
+      "version": "13.5.9",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-13.5.9.tgz",
+      "integrity": "sha512-W2HhVNUbC/tuFdzNMbnXAWsIHSg9SC9QWDNmFD3nXdSzlXNgL8NmuiwN2fkYvCQBtp/XSoy0gDLx0C+Fo19cfw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/x-global": "13.5.9",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/x-textdecoder/node_modules/@polkadot/x-global": {
+      "version": "13.5.9",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-13.5.9.tgz",
+      "integrity": "sha512-zSRWvELHd3Q+bFkkI1h2cWIqLo1ETm+MxkNXLec3lB56iyq/MjWBxfXnAFFYFayvlEVneo7CLHcp+YTFd9aVSA==",
+      "license": "Apache-2.0",
+      "dependencies": {
         "tslib": "^2.8.0"
       },
       "engines": {
@@ -1193,11 +1122,24 @@
       }
     },
     "node_modules/@polkadot/x-textencoder": {
-      "version": "13.3.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-13.3.1.tgz",
-      "integrity": "sha512-DnHLUdoKDYxekfxopuUuPB+j5Mu7Jemejcduu5gz3/89GP/sYPAu0CAVbq9B+hK1yGjBBj31eA4wkAV1oktYmg==",
+      "version": "13.5.9",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-13.5.9.tgz",
+      "integrity": "sha512-SG0MHnLUgn1ZxFdm0KzMdTHJ47SfqFhdIPMcGA0Mg/jt2rwrfrP3jtEIJMsHfQpHvfsNPfv55XOMmoPWuQnP/Q==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@polkadot/x-global": "13.3.1",
+        "@polkadot/x-global": "13.5.9",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@polkadot/x-textencoder/node_modules/@polkadot/x-global": {
+      "version": "13.5.9",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-13.5.9.tgz",
+      "integrity": "sha512-zSRWvELHd3Q+bFkkI1h2cWIqLo1ETm+MxkNXLec3lB56iyq/MjWBxfXnAFFYFayvlEVneo7CLHcp+YTFd9aVSA==",
+      "license": "Apache-2.0",
+      "dependencies": {
         "tslib": "^2.8.0"
       },
       "engines": {
@@ -7461,7 +7403,7 @@
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@polkadot/api": "^14.0.1",
-        "@polkadot/keyring": "^13.1.1",
+        "@polkadot/keyring": "^13.5.7",
         "@polkadot/util-crypto": "^13.5.7",
         "@zombienet/utils": "^0.0.30",
         "chai": "^4.3.10",

--- a/javascript/packages/cli/package.json
+++ b/javascript/packages/cli/package.json
@@ -67,6 +67,7 @@
   },
   "devDependencies": {
     "@types/cli-progress": "^3.11.5",
+    "@types/node": "^25.5.2",
     "@types/nunjucks": "^3.2.6",
     "pkg": "~5.8.1"
   },

--- a/javascript/packages/orchestrator/package.json
+++ b/javascript/packages/orchestrator/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "@polkadot/api": "^14.0.1",
-    "@polkadot/keyring": "^13.1.1",
+    "@polkadot/keyring": "^13.5.7",
     "@polkadot/util-crypto": "^13.5.7",
     "@zombienet/utils": "^0.0.30",
     "chai": "^4.3.10",

--- a/javascript/packages/orchestrator/package.json
+++ b/javascript/packages/orchestrator/package.json
@@ -62,7 +62,8 @@
     "@types/fs-extra": "^11.0.4",
     "@types/jsdom": "^21.1.6",
     "@types/minimatch": "^5.1.2",
-    "@types/mocha": "^10.0.6"
+    "@types/mocha": "^10.0.6",
+    "@types/node": "^25.5.2"
   },
   "homepage": "https://github.com/paritytech/zombienet#readme"
 }

--- a/javascript/packages/orchestrator/package.json
+++ b/javascript/packages/orchestrator/package.json
@@ -38,8 +38,8 @@
   },
   "dependencies": {
     "@polkadot/api": "^14.0.1",
-    "@polkadot/keyring": "^13.5.7",
-    "@polkadot/util-crypto": "^13.5.7",
+    "@polkadot/keyring": "^13.5.9",
+    "@polkadot/util-crypto": "^13.5.9",
     "@zombienet/utils": "^0.0.30",
     "chai": "^4.3.10",
     "debug": "^4.4.3",

--- a/javascript/packages/utils/package.json
+++ b/javascript/packages/utils/package.json
@@ -41,6 +41,7 @@
     "@types/chai": "^4.3.11",
     "@types/deep-equal-in-any-order": "^1.0.3",
     "@types/mocha": "^10.0.6",
+    "@types/node": "^25.5.2",
     "@types/nunjucks": "^3.2.6",
     "@types/sinon": "^17.0.3",
     "chai": "^4.3.10",


### PR DESCRIPTION
Currently when you try to run zombienet from main it fails due to misaligned js dependencies 

```bash
> nix run github:paritytech/zombienet#default -- version
@polkadot/util has multiple versions, ensure that there is only one installed.
Either remove and explicitly install matching versions or dedupe using your package manager.
The following conflicting packages were found:
	cjs 13.3.1	node_modules/zombienet/node_modules/@polkadot/util/cjs
	cjs 13.5.7	node_modules/zombienet/node_modules/@polkadot/util-crypto/node_modules/@polkadot/util/cjs
@polkadot/util-crypto has multiple versions, ensure that there is only one installed.
Either remove and explicitly install matching versions or dedupe using your package manager.
The following conflicting packages were found:
	cjs 13.3.1	node_modules/zombienet/node_modules/@polkadot/keyring/node_modules/@polkadot/util-crypto/cjs
	cjs 13.5.7	node_modules/zombienet/node_modules/@polkadot/util-crypto/cjs
1.3.138
```

* The PR is rebase on top of: https://github.com/paritytech/zombienet/pull/2159