### PR TITLE
`(default_)db_snapshot` handles 'file:://' paths

### DIFF
--- a/docs/src/database-snapshot-guide.md
+++ b/docs/src/database-snapshot-guide.md
@@ -37,3 +37,10 @@ tar -C parachain-snapshot/charlie/ -czf parachain.tgz data relay-data
 # Restoring a snapshot
 Zombienet will automatically download the `*.tgz` file to the respective folder for a run. However you can also download it manually, just ensure you extract the tar file in the correct directory, i.e. the root directory
 `chain-data/charlie/`
+
+The snapshot source is set with `default_db_snapshot` (at the `relaychain` level) or `db_snapshot` (per node), and can be either an `http(s)` URL or a local `file://` URL, e.g.:
+
+```
+[relaychain]
+default_db_snapshot = "file:///absolute/path/to/relaychain.tgz"
+```

--- a/docs/src/network-definition-spec.md
+++ b/docs/src/network-definition-spec.md
@@ -29,6 +29,7 @@ The network config can be provided both in `json` or `toml` format and each sect
 - `chain`: (String, default `rococo-local`) The chain name.
 - `chain_spec_path`: (String) Path to the chain spec file, **NOTE** should be the `plain` version to allow customizations.
 - `chain_spec_command`: (String) Command to generate the chain spec, **NOTE** can't be used in combination with `chain_spec_path`.
+- `default_db_snapshot`: (String) Source of a `.tgz` database snapshot to restore into every node of the `relaychain` before it starts. Accepts an `http(s)` URL or a local `file://` URL (absolute path).
 - `default_args`: (Array of strings) An array of arguments to use as default to pass to the `command`.
 - `default_substrate_cli_args_version`: (0|1|2) Allow to set the substrate cli args version (see: https://github.com/paritytech/substrate/pull/13384). By default zombienet will evaluate your binary and set the correct version, but that produces a small overhead that could be skipped if you set directly with this key.
 - `default_overrides`: (Array of objects) An array of overrides to upload to the nodes, objects with:
@@ -64,6 +65,7 @@ The network config can be provided both in `json` or `toml` format and each sect
     - name: (String) name of the `env` var.
     - value: (String| number) Value of the env var.
   - `bootnodes`: Array of bootnodes to use.
+  - `db_snapshot`: (String) Source of a `.tgz` database snapshot to restore into this node before it starts (overrides `default_db_snapshot`). Accepts an `http(s)` URL or a local `file://` URL (absolute path).
   - `overrides`: Array of `overrides` definitions.
   - `add_to_bootnodes`: (Boolean, default false) Add this node to the bootnode list.
   - `resources`: (Object) **Only** available in `kubernetes`, represent the resources `limits`/`reservations` needed by the node.

--- a/javascript/packages/utils/src/net.ts
+++ b/javascript/packages/utils/src/net.ts
@@ -5,6 +5,7 @@ import os from "os";
 import { Readable } from "stream";
 import { finished } from "stream/promises";
 import { ReadableStream } from "stream/web";
+import { fileURLToPath } from "url";
 import { decorators } from "./colors";
 
 const usedPorts = new Map<number, number>();
@@ -72,6 +73,10 @@ export async function getHostIp(): Promise<string> {
 
 export async function downloadFile(url: string, dest: string): Promise<void> {
   try {
+    if (url.startsWith("file://")) {
+      await fs.promises.copyFile(fileURLToPath(url), dest);
+      return;
+    }
     const response = await fetch(url);
     if (!response.ok) {
       console.warn(

--- a/javascript/packages/utils/src/specs/net.spec.ts
+++ b/javascript/packages/utils/src/specs/net.spec.ts
@@ -1,0 +1,29 @@
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "fs";
+import path from "path";
+import { pathToFileURL } from "url";
+
+import { assert } from "chai";
+import { downloadFile } from "../net";
+
+describe("Tests on module 'net';", () => {
+  const tmpDir = path.join(__dirname, "tmp_net_tests");
+
+  before(function () {
+    mkdirSync(tmpDir, { recursive: true });
+  });
+
+  after(function () {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("downloadFile copies from a file:// source", async () => {
+    const src = path.join(tmpDir, "source.txt");
+    const dest = path.join(tmpDir, "dest.txt");
+    const contents = "zombienet db snapshot";
+    writeFileSync(src, contents);
+
+    await downloadFile(pathToFileURL(src).toString(), dest);
+
+    assert.equal(readFileSync(dest, "utf8"), contents);
+  });
+});


### PR DESCRIPTION
We are about to setup zombienet for the Individuality repo which includes a bunch of long running initialization scripts. To not require to init the network on every run, we intend to let a GitHub runner yield periodically a initialized db as an artifact which can be download and re-used.

However, the only accepted source is `http(s)://`. We end up downloading the db, then re-running a http server which hosts the db so zombienet can download it into its directory.

**Solution:**
Accept `file://` paths.

